### PR TITLE
Dockerfile - 保留tzdata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,7 @@ COPY ./*-bili-sync-rs ./targets/
 RUN apk update && apk add --no-cache \
     ca-certificates \
     tzdata \
-    ffmpeg \
-    && cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
-    && echo "Asia/Shanghai" > /etc/timezone
+    ffmpeg
 
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
     mv ./targets/Linux-x86_64-bili-sync-rs ./bili-sync-rs; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@ RUN apk update && apk add --no-cache \
     tzdata \
     ffmpeg \
     && cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
-    && echo "Asia/Shanghai" > /etc/timezone \
-    && apk del tzdata
+    && echo "Asia/Shanghai" > /etc/timezone
 
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
     mv ./targets/Linux-x86_64-bili-sync-rs ./bili-sync-rs; \


### PR DESCRIPTION
删除`tzdata`后使用`date`显示为UTC，安装后恢复`date`显示北京时间，故保留`tzdata`以确保日志时间正确

```
~ # date
Wed May  1 11:42:54 UTC 2024
~ # apk add tzdata
(1/1) Installing tzdata (2024a-r0)
OK: 130 MiB in 120 packages
~ # date
Wed May  1 19:43:00 CST 2024
```