### PR TITLE
fix: 修复当目标文件已存在时 ffmpeg 卡住的问题

### DIFF
--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -40,6 +40,7 @@ impl Downloader {
                 audio_path.to_str().unwrap(),
                 "-c",
                 "copy",
+                "-y",
                 output_path.to_str().unwrap(),
             ])
             .output()


### PR DESCRIPTION
-y 参数可以让 ffmpeg 默认覆盖目标文件