### PR TITLE
fix: 修复类型错误导致的数值溢出

### DIFF
--- a/entity/src/entities/page.rs
+++ b/entity/src/entities/page.rs
@@ -8,7 +8,7 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,
     pub video_id: i32,
-    pub cid: i32,
+    pub cid: i64,
     pub pid: i32,
     pub name: String,
     pub width: Option<u32>,

--- a/src/bilibili/video.rs
+++ b/src/bilibili/video.rs
@@ -39,7 +39,7 @@ impl serde::Serialize for Tag {
 }
 #[derive(Debug, serde::Deserialize, Default)]
 pub struct PageInfo {
-    pub cid: i32,
+    pub cid: i64,
     pub page: i32,
     #[serde(rename = "part")]
     pub name: String,
@@ -92,7 +92,7 @@ impl<'a> Video<'a> {
     pub async fn get_danmaku_writer(&self, page: &'a PageInfo) -> Result<DanmakuWriter> {
         let tasks = FuturesUnordered::new();
         for i in 1..=(page.duration + 359) / 360 {
-            tasks.push(self.get_danmaku_segment(page, i as i32));
+            tasks.push(self.get_danmaku_segment(page, i as i64));
         }
         let result: Vec<Vec<DanmakuElem>> = tasks.try_collect().await?;
         let mut result: Vec<DanmakuElem> = result.into_iter().flatten().collect();
@@ -100,7 +100,7 @@ impl<'a> Video<'a> {
         Ok(DanmakuWriter::new(page, result.into_iter().map(|x| x.into()).collect()))
     }
 
-    async fn get_danmaku_segment(&self, page: &PageInfo, segment_idx: i32) -> Result<Vec<DanmakuElem>> {
+    async fn get_danmaku_segment(&self, page: &PageInfo, segment_idx: i64) -> Result<Vec<DanmakuElem>> {
         let mut res = self
             .client
             .request(Method::GET, "http://api.bilibili.com/x/v2/dm/web/seg.so")


### PR DESCRIPTION
过去分页 cid 使用的类型是 i32，今天遇到了溢出的情况：
<img width="1300" alt="image" src="https://github.com/amtoaer/bili-sync/assets/32017007/4ea08ff9-4d2b-4edb-ba91-77fdcc99b0b4">
将 i32 修改为 i64 以修复该问题。