### PR TITLE
fix: 修复 exist_labels 可能判断错误的问题

### DIFF
--- a/crates/bili_sync/src/adapter/collection.rs
+++ b/crates/bili_sync/src/adapter/collection.rs
@@ -117,7 +117,7 @@ impl VideoListModel for collection::Model {
                     .and(video::Column::Bvid.is_in(bvids)),
             )
             .select_only()
-            .columns([video::Column::Bvid, video::Column::Favtime])
+            .columns([video::Column::Bvid, video::Column::Pubtime])
             .into_tuple()
             .all(connection)
             .await?


### PR DESCRIPTION
Pubtime 和 Favtime 在获取视频详情时会填充为相同的值，所以这个 bug 基本不会触发。
对于极少数的触发情况，也只会导致多请求一些 b 站接口，对程序正常运行不会有影响。