### PR TITLE
feat: 引入更健壮的新视频检测方法

### DIFF
--- a/crates/bili_sync/src/adapter/collection.rs
+++ b/crates/bili_sync/src/adapter/collection.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::path::Path;
 use std::pin::Pin;
 
@@ -9,7 +8,7 @@ use futures::Stream;
 use sea_orm::entity::prelude::*;
 use sea_orm::sea_query::{IntoCondition, OnConflict};
 use sea_orm::ActiveValue::Set;
-use sea_orm::{DatabaseConnection, TransactionTrait};
+use sea_orm::{DatabaseConnection, TransactionTrait, Unchanged};
 
 use crate::adapter::{helper, VideoListModel};
 use crate::bilibili::{self, BiliClient, Collection, CollectionItem, CollectionType, VideoInfo};
@@ -17,10 +16,6 @@ use crate::utils::status::Status;
 
 #[async_trait]
 impl VideoListModel for collection::Model {
-    async fn video_count(&self, connection: &DatabaseConnection) -> Result<u64> {
-        helper::count_videos(video::Column::CollectionId.eq(self.id).into_condition(), connection).await
-    }
-
     async fn unfilled_videos(&self, connection: &DatabaseConnection) -> Result<Vec<video::Model>> {
         helper::filter_videos(
             video::Column::CollectionId
@@ -52,20 +47,6 @@ impl VideoListModel for collection::Model {
         .await
     }
 
-    async fn exist_labels(
-        &self,
-        videos_info: &[VideoInfo],
-        connection: &DatabaseConnection,
-    ) -> Result<HashSet<String>> {
-        helper::video_keys(
-            video::Column::CollectionId.eq(self.id),
-            videos_info,
-            [video::Column::Bvid, video::Column::Pubtime],
-            connection,
-        )
-        .await
-    }
-
     fn video_model_by_info(&self, video_info: &VideoInfo, base_model: Option<video::Model>) -> video::ActiveModel {
         let mut video_model = video_info.to_model(base_model);
         video_model.collection_id = Set(Some(self.id));
@@ -81,7 +62,7 @@ impl VideoListModel for collection::Model {
         let info: Result<_> = async { Ok((video.get_tags().await?, video.get_view_info().await?)) }.await;
         match info {
             Ok((tags, view_info)) => {
-                let VideoInfo::View { pages, .. } = &view_info else {
+                let VideoInfo::Detail { pages, .. } = &view_info else {
                     unreachable!("view_info must be VideoInfo::View")
                 };
                 let txn = connection.begin().await?;
@@ -98,6 +79,21 @@ impl VideoListModel for collection::Model {
                 helper::error_fetch_video_detail(e, video_model, connection).await?;
             }
         };
+        Ok(())
+    }
+
+    fn get_latest_row_at(&self) -> DateTime {
+        self.latest_row_at
+    }
+
+    async fn update_latest_row_at(&self, datetime: DateTime, connection: &DatabaseConnection) -> Result<()> {
+        collection::ActiveModel {
+            id: Unchanged(self.id),
+            latest_row_at: Set(datetime),
+            ..Default::default()
+        }
+        .update(connection)
+        .await?;
         Ok(())
     }
 
@@ -146,14 +142,13 @@ impl VideoListModel for collection::Model {
         );
     }
 
-    fn log_refresh_video_end(&self, got_count: usize, new_count: u64) {
+    fn log_refresh_video_end(&self, count: usize) {
         info!(
-            "扫描{}: {} - {} 的新视频完成，获取了 {} 条新视频，其中有 {} 条新视频",
+            "扫描{}: {} - {} 的新视频完成，获取了 {} 条新视频",
             CollectionType::from(self.r#type),
             self.s_id,
             self.name,
-            got_count,
-            new_count,
+            count,
         );
     }
 }

--- a/crates/bili_sync/src/adapter/mod.rs
+++ b/crates/bili_sync/src/adapter/mod.rs
@@ -4,7 +4,6 @@ mod helper;
 mod submission;
 mod watch_later;
 
-use std::collections::HashSet;
 use std::path::Path;
 use std::pin::Pin;
 
@@ -43,9 +42,6 @@ pub async fn video_list_from<'a>(
 
 #[async_trait]
 pub trait VideoListModel {
-    /// 与视频列表关联的视频总数
-    async fn video_count(&self, connection: &DatabaseConnection) -> Result<u64>;
-
     /// 未填充的视频
     async fn unfilled_videos(&self, connection: &DatabaseConnection) -> Result<Vec<bili_sync_entity::video::Model>>;
 
@@ -54,10 +50,6 @@ pub trait VideoListModel {
         &self,
         connection: &DatabaseConnection,
     ) -> Result<Vec<(bili_sync_entity::video::Model, Vec<bili_sync_entity::page::Model>)>>;
-
-    /// 该批次视频的存在标记
-    async fn exist_labels(&self, videos_info: &[VideoInfo], connection: &DatabaseConnection)
-        -> Result<HashSet<String>>;
 
     /// 视频信息对应的视频 model
     fn video_model_by_info(
@@ -73,6 +65,12 @@ pub trait VideoListModel {
         video_model: bili_sync_entity::video::Model,
         connection: &DatabaseConnection,
     ) -> Result<()>;
+
+    /// 获取视频 model 中记录的最新时间
+    fn get_latest_row_at(&self) -> DateTime;
+
+    /// 更新视频 model 中记录的最新时间
+    async fn update_latest_row_at(&self, datetime: DateTime, connection: &DatabaseConnection) -> Result<()>;
 
     /// 开始获取视频
     fn log_fetch_video_start(&self);
@@ -90,5 +88,5 @@ pub trait VideoListModel {
     fn log_refresh_video_start(&self);
 
     /// 结束刷新视频
-    fn log_refresh_video_end(&self, got_count: usize, new_count: u64);
+    fn log_refresh_video_end(&self, count: usize);
 }

--- a/crates/bili_sync/src/bilibili/mod.rs
+++ b/crates/bili_sync/src/bilibili/mod.rs
@@ -61,7 +61,7 @@ impl Validate for serde_json::Value {
 /// > Serde will try to match the data against each variant in order and the first one that deserializes successfully is the one returned.
 pub enum VideoInfo {
     /// 从视频详情接口获取的视频信息
-    View {
+    Detail {
         title: String,
         bvid: String,
         #[serde(rename = "desc")]
@@ -77,8 +77,8 @@ pub enum VideoInfo {
         pages: Vec<PageInfo>,
         state: i32,
     },
-    /// 从收藏夹中获取的视频信息
-    Detail {
+    /// 从收藏夹接口获取的视频信息
+    Favorite {
         title: String,
         #[serde(rename = "type")]
         vtype: i32,
@@ -94,7 +94,7 @@ pub enum VideoInfo {
         pubtime: DateTime<Utc>,
         attr: i32,
     },
-    /// 从稍后再看中获取的视频信息
+    /// 从稍后再看接口获取的视频信息
     WatchLater {
         title: String,
         bvid: String,
@@ -112,8 +112,8 @@ pub enum VideoInfo {
         pubtime: DateTime<Utc>,
         state: i32,
     },
-    /// 从视频列表中获取的视频信息
-    Simple {
+    /// 从视频合集/视频列表接口获取的视频信息
+    Collection {
         bvid: String,
         #[serde(rename = "pic")]
         cover: String,
@@ -122,6 +122,7 @@ pub enum VideoInfo {
         #[serde(rename = "pubdate", with = "ts_seconds")]
         pubtime: DateTime<Utc>,
     },
+    // 从用户投稿接口获取的视频信息
     Submission {
         title: String,
         bvid: String,
@@ -152,7 +153,7 @@ mod tests {
         };
         set_global_mixin_key(mixin_key);
         let video = Video::new(&bili_client, "BV1Z54y1C7ZB".to_string());
-        assert!(matches!(video.get_view_info().await, Ok(VideoInfo::View { .. })));
+        assert!(matches!(video.get_view_info().await, Ok(VideoInfo::Detail { .. })));
         let collection_item = CollectionItem {
             mid: "521722088".to_string(),
             sid: "387214".to_string(),
@@ -161,11 +162,11 @@ mod tests {
         let collection = Collection::new(&bili_client, &collection_item);
         let stream = collection.into_simple_video_stream();
         pin_mut!(stream);
-        assert!(matches!(stream.next().await, Some(VideoInfo::Simple { .. })));
+        assert!(matches!(stream.next().await, Some(VideoInfo::Collection { .. })));
         let favorite = FavoriteList::new(&bili_client, "3084505258".to_string());
         let stream = favorite.into_video_stream();
         pin_mut!(stream);
-        assert!(matches!(stream.next().await, Some(VideoInfo::Detail { .. })));
+        assert!(matches!(stream.next().await, Some(VideoInfo::Favorite { .. })));
         let watch_later = WatchLater::new(&bili_client);
         let stream = watch_later.into_video_stream();
         pin_mut!(stream);

--- a/crates/bili_sync/src/utils/mod.rs
+++ b/crates/bili_sync/src/utils/mod.rs
@@ -4,7 +4,6 @@ pub mod model;
 pub mod nfo;
 pub mod status;
 
-use chrono::{DateTime, Utc};
 use tracing_subscriber::util::SubscriberInitExt;
 
 pub fn init_logger(log_level: &str) {
@@ -16,9 +15,4 @@ pub fn init_logger(log_level: &str) {
         .finish()
         .try_init()
         .expect("初始化日志失败");
-}
-
-/// 生成视频的唯一标记，均由 bvid 和时间戳构成
-pub fn id_time_key(bvid: &String, time: &DateTime<Utc>) -> String {
-    format!("{}-{}", bvid, time.timestamp())
 }

--- a/crates/bili_sync_entity/src/entities/collection.rs
+++ b/crates/bili_sync_entity/src/entities/collection.rs
@@ -13,6 +13,7 @@ pub struct Model {
     pub r#type: i32,
     pub path: String,
     pub created_at: String,
+    pub latest_row_at: DateTime,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/bili_sync_entity/src/entities/favorite.rs
+++ b/crates/bili_sync_entity/src/entities/favorite.rs
@@ -12,6 +12,7 @@ pub struct Model {
     pub name: String,
     pub path: String,
     pub created_at: String,
+    pub latest_row_at: DateTime,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/bili_sync_entity/src/entities/submission.rs
+++ b/crates/bili_sync_entity/src/entities/submission.rs
@@ -11,6 +11,7 @@ pub struct Model {
     pub upper_name: String,
     pub path: String,
     pub created_at: String,
+    pub latest_row_at: DateTime,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/bili_sync_entity/src/entities/watch_later.rs
+++ b/crates/bili_sync_entity/src/entities/watch_later.rs
@@ -9,6 +9,7 @@ pub struct Model {
     pub id: i32,
     pub path: String,
     pub created_at: String,
+    pub latest_row_at: DateTime,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/bili_sync_migration/src/lib.rs
+++ b/crates/bili_sync_migration/src/lib.rs
@@ -4,6 +4,7 @@ mod m20240322_000001_create_table;
 mod m20240505_130850_add_collection;
 mod m20240709_130914_watch_later;
 mod m20240724_161008_submission;
+mod m20250122_062926_add_latest_row_at;
 
 pub struct Migrator;
 
@@ -15,6 +16,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20240505_130850_add_collection::Migration),
             Box::new(m20240709_130914_watch_later::Migration),
             Box::new(m20240724_161008_submission::Migration),
+            Box::new(m20250122_062926_add_latest_row_at::Migration),
         ]
     }
 }

--- a/crates/bili_sync_migration/src/m20250122_062926_add_latest_row_at.rs
+++ b/crates/bili_sync_migration/src/m20250122_062926_add_latest_row_at.rs
@@ -1,0 +1,122 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::schema::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // 为四张 video list 表添加 latest_row_at 字段，表示该列表处理到的最新时间
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Favorite::Table)
+                    .add_column(timestamp(Favorite::LatestRowAt).default("1970-01-01 00:00:00"))
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Collection::Table)
+                    .add_column(timestamp(Collection::LatestRowAt).default("1970-01-01 00:00:00"))
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(WatchLater::Table)
+                    .add_column(timestamp(WatchLater::LatestRowAt).default("1970-01-01 00:00:00"))
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Submission::Table)
+                    .add_column(timestamp(Submission::LatestRowAt).default("1970-01-01 00:00:00"))
+                    .to_owned(),
+            )
+            .await?;
+        // 手动写 SQL 更新这四张表的 latest 字段到当前取值
+        let db = manager.get_connection();
+        db.execute_unprepared(
+            "UPDATE favorite SET latest_row_at = (SELECT IFNULL(MAX(favtime), '1970-01-01 00:00:00') FROM video WHERE favorite_id = favorite.id)",
+        )
+        .await?;
+        db.execute_unprepared(
+            "UPDATE collection SET latest_row_at = (SELECT IFNULL(MAX(pubtime), '1970-01-01 00:00:00') FROM video WHERE collection_id = collection.id)",
+        )
+        .await?;
+        db.execute_unprepared(
+            "UPDATE watch_later SET latest_row_at = (SELECT IFNULL(MAX(favtime), '1970-01-01 00:00:00') FROM video WHERE watch_later_id = watch_later.id)",
+        )
+        .await?;
+        db.execute_unprepared(
+            "UPDATE submission SET latest_row_at = (SELECT IFNULL(MAX(ctime), '1970-01-01 00:00:00') FROM video WHERE submission_id = submission.id)",
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Favorite::Table)
+                    .drop_column(Favorite::LatestRowAt)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Collection::Table)
+                    .drop_column(Collection::LatestRowAt)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(WatchLater::Table)
+                    .drop_column(WatchLater::LatestRowAt)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Submission::Table)
+                    .drop_column(Submission::LatestRowAt)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Favorite {
+    Table,
+    LatestRowAt,
+}
+
+#[derive(DeriveIden)]
+enum Collection {
+    Table,
+    LatestRowAt,
+}
+
+#[derive(DeriveIden)]
+enum WatchLater {
+    Table,
+    LatestRowAt,
+}
+
+#[derive(DeriveIden)]
+enum Submission {
+    Table,
+    LatestRowAt,
+}


### PR DESCRIPTION
## 当前的新视频检测逻辑
1. 从新到旧分页拉取视频（优先请求新视频）
2. 按照拉取顺序分批写入到数据库中（避免对象囤积，节省内存）
3. 当发现数据库中有“bvid、时间”重合的数据时认为到达了上次处理到的位置，中断任务（避免重复请求，减少请求次数）

## 缺点
当前的检测逻辑大多时候可以工作正常，但无法防御一些边缘情况，主要有两点。

### 1. 接口请求过程中发生视频新增操作

请求第一页并写入到数据库的过程中，用户又收藏、更新了一条视频，这样第一页的最后一个视频被挤到了第二页的第一个。
这样在处理第二页时，会发现数据库中有“bvid、时间”重合的数据，错误触发了中断逻辑，导致后续的未处理视频丢失。

### 2. 接口上页请求成功而下页请求失败

为了避免对象囤积节省内存，当前将视频写入数据库的顺序和接口的请求顺序是相同的，均为从新到旧。
如果有多页新视频，第一页请求成功且正确写入，第二页由于网络等原因请求错误，当前的处理逻辑是直接中断等待下次运行。
下次运行这个任务时，第一页这些较新的视频会触发中断逻辑，导致后续页面永久丢失，无法再处理。

## 解决方案

不难看出当前问题在于检测逻辑**过于信任检测过程中产生的部分结果，导致对上次处理到的位置判断错误**，要解决这个问题需要维护一个在整个检测过程完成才更新的值。

因此该 PR 为所有的 video list 表引入了 `latest_row_at` 字段，记录了最后处理的视频时间，该字段会在新视频检测运行全部完成时被更新为最大的视频时间。

中断的唯一判断条件是当前处理到的视频时间 `<= latest_row_at`。