### PR TITLE
refactor: 下载部分使用 tokio 的封装代替手动实现

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,7 @@ dependencies = [
  "strum",
  "thiserror 2.0.11",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -3274,9 +3275,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ serde_urlencoded = "0.7.1"
 strum = { version = "0.26.3", features = ["derive"] }
 thiserror = "2.0.11"
 tokio = { version = "1.43.0", features = ["full"] }
+tokio-util = { version = "0.7.13", features = ["io"] }
 toml = "0.8.19"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["chrono"] }

--- a/crates/bili_sync/Cargo.toml
+++ b/crates/bili_sync/Cargo.toml
@@ -41,6 +41,7 @@ serde_urlencoded = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION
copy 内部维护固定 8kb 大小的缓冲区，而手动 for 循环的 bytes 会偶尔出现 4kb 乃至更小的数据包，更换后应该能少幅度减少写入频率。