### PR TITLE
chore: error 会打印更加详细的信息，修正常见错误的判断

### DIFF
--- a/crates/bili_sync/src/error.rs
+++ b/crates/bili_sync/src/error.rs
@@ -24,15 +24,20 @@ impl From<Result<ExecutionStatus>> for ExecutionStatus {
         match res {
             Ok(status) => status,
             Err(err) => {
-                // error decoding response body
-                if let Some(error) = err.downcast_ref::<reqwest::Error>() {
-                    if error.is_decode() {
+                if let Some(error) = err.downcast_ref::<io::Error>() {
+                    let error_kind = error.kind();
+                    if error_kind == io::ErrorKind::PermissionDenied
+                        || (error_kind == io::ErrorKind::Other
+                            && error.get_ref().is_some_and(|e| {
+                                e.downcast_ref::<reqwest::Error>()
+                                    .is_some_and(|e| e.is_decode() || e.is_body() || e.is_timeout())
+                            }))
+                    {
                         return ExecutionStatus::Ignored(err);
                     }
                 }
-                // 文件系统的权限错误
-                if let Some(error) = err.downcast_ref::<io::Error>() {
-                    if error.kind() == io::ErrorKind::PermissionDenied {
+                if let Some(error) = err.downcast_ref::<reqwest::Error>() {
+                    if error.is_decode() || error.is_body() || error.is_timeout() {
                         return ExecutionStatus::Ignored(err);
                     }
                 }

--- a/crates/bili_sync/src/task/video_downloader.rs
+++ b/crates/bili_sync/src/task/video_downloader.rs
@@ -23,20 +23,20 @@ pub async fn video_downloader(connection: Arc<DatabaseConnection>) {
                     break 'inner;
                 }
                 Err(e) => {
-                    error!("获取 mixin key 遇到错误：{e}，等待下一轮执行");
+                    error!("获取 mixin key 遇到错误：{:#}，等待下一轮执行", e);
                     break 'inner;
                 }
             };
             if anchor != chrono::Local::now().date_naive() {
                 if let Err(e) = bili_client.check_refresh().await {
-                    error!("检查刷新 Credential 遇到错误：{e}，等待下一轮执行");
+                    error!("检查刷新 Credential 遇到错误：{:#}，等待下一轮执行", e);
                     break 'inner;
                 }
                 anchor = chrono::Local::now().date_naive();
             }
             for (args, path) in &params {
                 if let Err(e) = process_video_source(*args, &bili_client, path, &connection).await {
-                    error!("处理过程遇到错误：{e}");
+                    error!("处理过程遇到错误：{:#}", e);
                 }
             }
             info!("本轮任务执行完毕，等待下一轮执行");

--- a/crates/bili_sync/src/workflow.rs
+++ b/crates/bili_sync/src/workflow.rs
@@ -109,7 +109,7 @@ pub async fn fetch_video_details(
         match info {
             Err(e) => {
                 error!(
-                    "获取视频 {} - {} 的详细信息失败，错误为：{}",
+                    "获取视频 {} - {} 的详细信息失败，错误为：{:#}",
                     &video_model.bvid, &video_model.name, e
                 );
                 if let Some(BiliError::RequestFailed(-404, _)) = e.downcast_ref::<BiliError>() {
@@ -270,11 +270,11 @@ pub async fn download_video_pages(
             ExecutionStatus::Succeeded => info!("处理视频「{}」{}成功", &video_model.name, task_name),
             ExecutionStatus::Ignored(e) => {
                 error!(
-                    "处理视频「{}」{}出现常见错误，已忽略: {}",
+                    "处理视频「{}」{}出现常见错误，已忽略: {:#}",
                     &video_model.name, task_name, e
                 )
             }
-            ExecutionStatus::Failed(e) => error!("处理视频「{}」{}失败: {}", &video_model.name, task_name, e),
+            ExecutionStatus::Failed(e) => error!("处理视频「{}」{}失败: {:#}", &video_model.name, task_name, e),
         });
     if let ExecutionStatus::Failed(e) = results.into_iter().nth(4).context("page download result not found")? {
         if e.downcast_ref::<DownloadAbortError>().is_some() {
@@ -469,12 +469,12 @@ pub async fn download_page(
             ),
             ExecutionStatus::Ignored(e) => {
                 error!(
-                    "处理视频「{}」第 {} 页{}出现常见错误，已忽略: {}",
+                    "处理视频「{}」第 {} 页{}出现常见错误，已忽略: {:#}",
                     &video_model.name, page_model.pid, task_name, e
                 )
             }
             ExecutionStatus::Failed(e) => error!(
-                "处理视频「{}」第 {} 页{}失败: {}",
+                "处理视频「{}」第 {} 页{}失败: {:#}",
                 &video_model.name, page_model.pid, task_name, e
             ),
         });


### PR DESCRIPTION
1. 使用 :# 来展示更加详细的错误信息
2. 常见的 error decode response body 可能是包裹在 io::Error::Custom 之中的，需要展开再匹配