### PR TITLE
fix: 修复 video 中分 p 下载状态的设置

### DIFF
--- a/crates/bili_sync/src/error.rs
+++ b/crates/bili_sync/src/error.rs
@@ -16,6 +16,8 @@ pub enum ExecutionStatus {
     Succeeded,
     Ignored(anyhow::Error),
     Failed(anyhow::Error),
+    // 任务可以返回该状态固定自己的 status
+    FixedFailed(u32, anyhow::Error),
 }
 
 // 目前 stable rust 似乎不支持自定义类型使用 ? 运算符，只能先在返回值使用 Result，再这样套层娃


### PR DESCRIPTION
详见注释，除了能解决一般情况的分 p 下载状态标记不准确问题，还能修复分页返回 Ignored Error 时产生的逻辑错误。