### PR TITLE
feat: 下载时考虑 backup_url，支持按照 cdn 优先级排序

### DIFF
--- a/crates/bili_sync/src/config/global.rs
+++ b/crates/bili_sync/src/config/global.rs
@@ -81,6 +81,7 @@ fn load_config() -> Config {
     };
     Config {
         credential: arc_swap::ArcSwapOption::from(credential),
+        cdn_sorting: true,
         ..Default::default()
     }
 }

--- a/crates/bili_sync/src/config/mod.rs
+++ b/crates/bili_sync/src/config/mod.rs
@@ -69,6 +69,8 @@ pub struct Config {
     pub concurrent_limit: ConcurrentLimit,
     #[serde(default = "default_time_format")]
     pub time_format: String,
+    #[serde(default)]
+    pub cdn_sorting: bool,
 }
 
 impl Default for Config {
@@ -90,6 +92,7 @@ impl Default for Config {
             nfo_time_type: NFOTimeType::FavTime,
             concurrent_limit: ConcurrentLimit::default(),
             time_format: default_time_format(),
+            cdn_sorting: false,
         }
     }
 }


### PR DESCRIPTION
b 站下载链接返回时会包含一个 baseUrl 和两个 backupUrl，之前只会尝试访问 baseUrl。

新的实现会将三个 url 统一作视为视频的下载链接，并依次尝试下载。

默认情况下，url 的请求顺序是 baseUrl -> backupUrl。该 PR 同时引入了 cdn_sorting 配置，默认为 false。如果启用，三个 url 的顺序会按照如下优先级进行排序：
![48b72cde-f023-4092-907c-bce0c54bec07](https://github.com/user-attachments/assets/25212add-9f19-4423-868c-8c0ae1758e56)
