### PR TITLE
fix: 视频合集/视频列表改为全量拉取，确保正确更新

### DIFF
--- a/crates/bili_sync/src/adapter/collection.rs
+++ b/crates/bili_sync/src/adapter/collection.rs
@@ -50,7 +50,7 @@ impl VideoSource for collection::Model {
 
     fn log_refresh_video_end(&self, count: usize) {
         info!(
-            "扫描{}「{}」完成，获取到 {} 条新视频",
+            "扫描{}「{}」完成，已拉取 {} 条视频",
             CollectionType::from(self.r#type),
             self.name,
             count,

--- a/crates/bili_sync/src/adapter/collection.rs
+++ b/crates/bili_sync/src/adapter/collection.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 
 use anyhow::{Context, Result};
 use bili_sync_entity::*;
+use chrono::Utc;
 use futures::Stream;
 use sea_orm::ActiveValue::Set;
 use sea_orm::entity::prelude::*;
@@ -35,6 +36,12 @@ impl VideoSource for collection::Model {
             latest_row_at: Set(datetime),
             ..Default::default()
         })
+    }
+
+    fn should_take(&self, _release_datetime: &chrono::DateTime<Utc>, _latest_row_at: &chrono::DateTime<Utc>) -> bool {
+        // collection（视频合集/视频列表）返回的内容似乎并非严格按照时间排序，并且不同 collection 的排序方式也不同
+        // 为了保证程序正确性，collection 不根据时间提前 break，而是每次都全量拉取
+        true
     }
 
     fn log_refresh_video_start(&self) {

--- a/crates/bili_sync/src/adapter/mod.rs
+++ b/crates/bili_sync/src/adapter/mod.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use std::pin::Pin;
 
 use anyhow::Result;
+use chrono::Utc;
 use enum_dispatch::enum_dispatch;
 use futures::Stream;
 use sea_orm::DatabaseConnection;
@@ -51,6 +52,11 @@ pub trait VideoSource {
     /// 不同 VideoSource 返回的类型不同，为了 VideoSource 的 object safety 不能使用 impl Trait
     /// Box<dyn ActiveModelTrait> 又提示 ActiveModelTrait 没有 object safety，因此手写一个 Enum 静态分发
     fn update_latest_row_at(&self, datetime: DateTime) -> _ActiveModel;
+
+    // 判断是否应该继续拉取视频
+    fn should_take(&self, release_datetime: &chrono::DateTime<Utc>, latest_row_at: &chrono::DateTime<Utc>) -> bool {
+        release_datetime > latest_row_at
+    }
 
     /// 开始刷新视频
     fn log_refresh_video_start(&self);

--- a/crates/bili_sync/src/workflow.rs
+++ b/crates/bili_sync/src/workflow.rs
@@ -72,7 +72,7 @@ pub async fn refresh_video_source<'a>(
                     if release_datetime > &max_datetime {
                         max_datetime = *release_datetime;
                     }
-                    futures::future::ready(release_datetime > &latest_row_at)
+                    futures::future::ready(video_source.should_take(release_datetime, &latest_row_at))
                 }
             }
         })


### PR DESCRIPTION
详见 https://github.com/amtoaer/bili-sync/issues/289 中的讨论，不清楚 b 站视频合集/视频列表是怎样排序的，现有基于时间的提前 break 逻辑不能适用。

改成全量拉取保证程序正确性。