### PR TITLE
refactor: 调整视频列表/视频合集的扫描逻辑，优化性能

### DIFF
--- a/crates/bili_sync/src/adapter/mod.rs
+++ b/crates/bili_sync/src/adapter/mod.rs
@@ -58,6 +58,15 @@ pub trait VideoSource {
         release_datetime > latest_row_at
     }
 
+    fn should_filter(
+        &self,
+        video_info: Result<VideoInfo, anyhow::Error>,
+        _latest_row_at: &chrono::DateTime<Utc>,
+    ) -> Option<VideoInfo> {
+        // 视频按照时间顺序拉取，should_take 已经获取了所有需要处理的视频，should_filter 无需额外处理
+        video_info.ok()
+    }
+
     /// 开始刷新视频
     fn log_refresh_video_start(&self);
 

--- a/crates/bili_sync/src/workflow.rs
+++ b/crates/bili_sync/src/workflow.rs
@@ -76,7 +76,7 @@ pub async fn refresh_video_source<'a>(
                 }
             }
         })
-        .filter_map(|res| futures::future::ready(res.ok()))
+        .filter_map(|res| futures::future::ready(video_source.should_filter(res, &latest_row_at)))
         .chunks(10);
     let mut count = 0;
     while let Some(videos_info) = video_streams.next().await {


### PR DESCRIPTION
在上次的改动（#290）后，视频合集和视频列表在每次扫描时都会尝试 insert 所有视频，在发生冲突时忽略。虽然逻辑上正确，但这导致了很多无意义的数据库访问，可以通过优化 take_while 后续的 filter_map 逻辑来避免。

该修改应该可以显著改善视频列表/视频合集的扫描性能。