### PR TITLE
chore: 大幅缩减构建结果的二进制文件体积

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4038,7 +4038,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 [[package]]
 name = "utoipa"
 version = "5.3.1"
-source = "git+https://github.com/amtoaer/utoipa.git?tag=v1.0.0#24742d6a32dcf1e89dcb159df9242d33cd73e2f1"
+source = "git+https://github.com/amtoaer/utoipa.git?tag=v1.0.1#6d66603333218fe4d0f36e40fc662628c6682a79"
 dependencies = [
  "indexmap",
  "serde",
@@ -4049,7 +4049,7 @@ dependencies = [
 [[package]]
 name = "utoipa-gen"
 version = "5.3.1"
-source = "git+https://github.com/amtoaer/utoipa.git?tag=v1.0.0#24742d6a32dcf1e89dcb159df9242d33cd73e2f1"
+source = "git+https://github.com/amtoaer/utoipa.git?tag=v1.0.1#6d66603333218fe4d0f36e40fc662628c6682a79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "utoipa-swagger-ui"
 version = "9.0.0"
-source = "git+https://github.com/amtoaer/utoipa.git?tag=v1.0.0#24742d6a32dcf1e89dcb159df9242d33cd73e2f1"
+source = "git+https://github.com/amtoaer/utoipa.git?tag=v1.0.1#6d66603333218fe4d0f36e40fc662628c6682a79"
 dependencies = [
  "axum",
  "base64",
@@ -4078,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "utoipa-swagger-ui-vendored"
 version = "0.1.2"
-source = "git+https://github.com/amtoaer/utoipa.git?tag=v1.0.0#24742d6a32dcf1e89dcb159df9242d33cd73e2f1"
+source = "git+https://github.com/amtoaer/utoipa.git?tag=v1.0.1#6d66603333218fe4d0f36e40fc662628c6682a79"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2801,20 +2801,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-embed"
-version = "8.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025908b8682a26ba8d12f6f2d66b987584a4a87bc024abc5bbc12553a8cd178a"
-dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
 name = "rust-embed-for-web"
 version = "11.2.1"
-source = "git+https://github.com/amtoaer/rust-embed-for-web?tag=1.0.2#e21cec8f3af2bf3f78d5c799f9a293c9ab444510"
+source = "git+https://github.com/amtoaer/rust-embed-for-web?tag=v1.0.0#b6eeb475cbe1ad5cae02d5373a1bba12ea58a869"
 dependencies = [
  "rust-embed-for-web-impl",
  "rust-embed-for-web-utils",
@@ -2824,7 +2813,7 @@ dependencies = [
 [[package]]
 name = "rust-embed-for-web-impl"
 version = "11.2.1"
-source = "git+https://github.com/amtoaer/rust-embed-for-web?tag=1.0.2#e21cec8f3af2bf3f78d5c799f9a293c9ab444510"
+source = "git+https://github.com/amtoaer/rust-embed-for-web?tag=v1.0.0#b6eeb475cbe1ad5cae02d5373a1bba12ea58a869"
 dependencies = [
  "brotli",
  "flate2",
@@ -2840,36 +2829,13 @@ dependencies = [
 [[package]]
 name = "rust-embed-for-web-utils"
 version = "11.2.1"
-source = "git+https://github.com/amtoaer/rust-embed-for-web?tag=1.0.2#e21cec8f3af2bf3f78d5c799f9a293c9ab444510"
+source = "git+https://github.com/amtoaer/rust-embed-for-web?tag=v1.0.0#b6eeb475cbe1ad5cae02d5373a1bba12ea58a869"
 dependencies = [
  "base85rs",
  "chrono",
  "enum_dispatch",
  "globset",
  "new_mime_guess",
- "sha2",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "8.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6065f1a4392b71819ec1ea1df1120673418bf386f50de1d6f54204d836d4349c"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn 2.0.96",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "8.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6cc0c81648b20b70c491ff8cce00c1c3b223bb8ed2b5d41f0e54c6c4c0a3594"
-dependencies = [
  "sha2",
  "walkdir",
 ]
@@ -4072,8 +4038,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 [[package]]
 name = "utoipa"
 version = "5.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435c6f69ef38c9017b4b4eea965dfb91e71e53d869e896db40d1cf2441dd75c0"
+source = "git+https://github.com/amtoaer/utoipa.git?tag=v1.0.0#24742d6a32dcf1e89dcb159df9242d33cd73e2f1"
 dependencies = [
  "indexmap",
  "serde",
@@ -4084,8 +4049,7 @@ dependencies = [
 [[package]]
 name = "utoipa-gen"
 version = "5.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77d306bc75294fd52f3e99b13ece67c02c1a2789190a6f31d32f736624326f7"
+source = "git+https://github.com/amtoaer/utoipa.git?tag=v1.0.0#24742d6a32dcf1e89dcb159df9242d33cd73e2f1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4096,14 +4060,13 @@ dependencies = [
 [[package]]
 name = "utoipa-swagger-ui"
 version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161166ec520c50144922a625d8bc4925cc801b2dda958ab69878527c0e5c5d61"
+source = "git+https://github.com/amtoaer/utoipa.git?tag=v1.0.0#24742d6a32dcf1e89dcb159df9242d33cd73e2f1"
 dependencies = [
  "axum",
  "base64",
  "mime_guess",
  "regex",
- "rust-embed",
+ "rust-embed-for-web",
  "serde",
  "serde_json",
  "url",
@@ -4115,8 +4078,7 @@ dependencies = [
 [[package]]
 name = "utoipa-swagger-ui-vendored"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
+source = "git+https://github.com/amtoaer/utoipa.git?tag=v1.0.0#24742d6a32dcf1e89dcb159df9242d33cd73e2f1"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +454,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "base85rs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87678d33a2af71f019ed11f52db246ca6c5557edee2cccbe689676d1ad9c6b5a"
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,7 +499,6 @@ dependencies = [
  "leaky-bucket",
  "md5",
  "memchr",
- "mime_guess",
  "once_cell",
  "prost",
  "quick-xml",
@@ -486,7 +506,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rsa",
- "rust-embed",
+ "rust-embed-for-web",
  "sea-orm",
  "serde",
  "serde_json",
@@ -594,6 +614,37 @@ dependencies = [
  "quote",
  "syn 2.0.96",
  "syn_derive",
+]
+
+[[package]]
+name = "brotli"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1322,6 +1373,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1965,6 +2029,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "new_mime_guess"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a2dfb3559d53e90b709376af1c379462f7fb3085a0177deb73e6ea0d99eff4"
+dependencies = [
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -2738,6 +2812,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed-for-web"
+version = "11.2.1"
+source = "git+https://github.com/amtoaer/rust-embed-for-web?tag=1.0.2#e21cec8f3af2bf3f78d5c799f9a293c9ab444510"
+dependencies = [
+ "rust-embed-for-web-impl",
+ "rust-embed-for-web-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-for-web-impl"
+version = "11.2.1"
+source = "git+https://github.com/amtoaer/rust-embed-for-web?tag=1.0.2#e21cec8f3af2bf3f78d5c799f9a293c9ab444510"
+dependencies = [
+ "brotli",
+ "flate2",
+ "globset",
+ "proc-macro2",
+ "quote",
+ "rust-embed-for-web-utils",
+ "shellexpand",
+ "syn 2.0.96",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-for-web-utils"
+version = "11.2.1"
+source = "git+https://github.com/amtoaer/rust-embed-for-web?tag=1.0.2#e21cec8f3af2bf3f78d5c799f9a293c9ab444510"
+dependencies = [
+ "base85rs",
+ "chrono",
+ "enum_dispatch",
+ "globset",
+ "new_mime_guess",
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rust-embed-impl"
 version = "8.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,6 +3240,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ hex = "0.4.3"
 leaky-bucket = "1.1.2"
 md5 = "0.7.0"
 memchr = "2.7.4"
-mime_guess = "2.0.5"
 once_cell = "1.21.3"
 prost = "0.13.5"
 quick-xml = { version = "0.37.5", features = ["async-tokio"] }
@@ -53,7 +52,7 @@ reqwest = { version = "0.12.15", features = [
     "stream",
 ], default-features = false }
 rsa = { version = "0.9.8", features = ["sha2"] }
-rust-embed = "8.7.2"
+rust-embed-for-web = { git = "https://github.com/amtoaer/rust-embed-for-web", tag = "1.0.2" }
 sea-orm = { version = "1.1.11", features = [
     "macros",
     "runtime-tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,10 +70,10 @@ toml = "0.8.22"
 tower = "0.5.2"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["chrono"] }
-utoipa = { git = "https://github.com/amtoaer/utoipa.git", tag = "v1.0.0", features = [
+utoipa = { git = "https://github.com/amtoaer/utoipa.git", tag = "v1.0.1", features = [
     "axum_extras",
 ] }
-utoipa-swagger-ui = { git = "https://github.com/amtoaer/utoipa.git", tag = "v1.0.0", features = [
+utoipa-swagger-ui = { git = "https://github.com/amtoaer/utoipa.git", tag = "v1.0.1", features = [
     "axum",
     "vendored",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ reqwest = { version = "0.12.15", features = [
     "stream",
 ], default-features = false }
 rsa = { version = "0.9.8", features = ["sha2"] }
-rust-embed-for-web = { git = "https://github.com/amtoaer/rust-embed-for-web", tag = "1.0.2" }
+rust-embed-for-web = { git = "https://github.com/amtoaer/rust-embed-for-web", tag = "v1.0.0" }
 sea-orm = { version = "1.1.11", features = [
     "macros",
     "runtime-tokio-rustls",
@@ -70,8 +70,13 @@ toml = "0.8.22"
 tower = "0.5.2"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["chrono"] }
-utoipa = { version = "5.3.1", features = ["axum_extras"] }
-utoipa-swagger-ui = { version = "9.0.0", features = ["axum", "vendored"] }
+utoipa = { git = "https://github.com/amtoaer/utoipa.git", tag = "v1.0.0", features = [
+    "axum_extras",
+] }
+utoipa-swagger-ui = { git = "https://github.com/amtoaer/utoipa.git", tag = "v1.0.0", features = [
+    "axum",
+    "vendored",
+] }
 validator = { version = "0.20.0", features = ["derive"] }
 
 [workspace.metadata.release]

--- a/crates/bili_sync/Cargo.toml
+++ b/crates/bili_sync/Cargo.toml
@@ -29,7 +29,6 @@ hex = { workspace = true }
 leaky-bucket = { workspace = true }
 md5 = { workspace = true }
 memchr = { workspace = true }
-mime_guess = { workspace = true }
 once_cell = { workspace = true }
 prost = { workspace = true }
 quick-xml = { workspace = true }
@@ -37,7 +36,7 @@ rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 rsa = { workspace = true }
-rust-embed = { workspace = true }
+rust-embed-for-web = { workspace = true }
 sea-orm = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/bili_sync/src/api/request.rs
+++ b/crates/bili_sync/src/api/request.rs
@@ -28,7 +28,7 @@ pub struct PageStatusUpdate {
 }
 
 #[derive(Deserialize, ToSchema, Validate)]
-pub struct ResetVideoStatusRequest {
+pub struct UpdateVideoStatusRequest {
     #[serde(default)]
     #[validate(nested)]
     pub video_updates: Vec<StatusUpdate>,

--- a/crates/bili_sync/src/api/response.rs
+++ b/crates/bili_sync/src/api/response.rs
@@ -40,7 +40,7 @@ pub struct ResetAllVideosResponse {
 }
 
 #[derive(Serialize, ToSchema)]
-pub struct ResetVideoStatusResponse {
+pub struct UpdateVideoStatusResponse {
     pub success: bool,
     pub video: VideoInfo,
     pub pages: Vec<PageInfo>,
@@ -58,6 +58,7 @@ pub struct VideoInfo {
     pub id: i32,
     pub name: String,
     pub upper_name: String,
+    #[schema(value_type = [u32; 5])]
     #[serde(serialize_with = "serde_video_download_status")]
     pub download_status: u32,
 }
@@ -69,6 +70,7 @@ pub struct PageInfo {
     pub video_id: i32,
     pub pid: i32,
     pub name: String,
+    #[schema(value_type = [u32; 5])]
     #[serde(serialize_with = "serde_page_download_status")]
     pub download_status: u32,
 }

--- a/crates/bili_sync/src/task/http_server.rs
+++ b/crates/bili_sync/src/task/http_server.rs
@@ -15,7 +15,7 @@ use utoipa_swagger_ui::{Config, SwaggerUi};
 
 use crate::api::auth;
 use crate::api::handler::{
-    ApiDoc, get_video, get_video_sources, get_videos, reset_all_videos, reset_video, reset_video_status,
+    ApiDoc, get_video, get_video_sources, get_videos, reset_all_videos, reset_video, update_video_status,
 };
 use crate::config::CONFIG;
 
@@ -31,7 +31,7 @@ pub async fn http_server(database_connection: Arc<DatabaseConnection>) -> Result
         .route("/api/videos", get(get_videos))
         .route("/api/videos/{id}", get(get_video))
         .route("/api/videos/{id}/reset", post(reset_video))
-        .route("/api/videos/{id}/reset-status", post(reset_video_status))
+        .route("/api/videos/{id}/update-status", post(update_video_status))
         .route("/api/videos/reset-all", post(reset_all_videos))
         .merge(
             SwaggerUi::new("/swagger-ui/")

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -6,8 +6,8 @@ import type {
 	VideoResponse,
 	ResetVideoResponse,
 	ResetAllVideosResponse,
-	ResetVideoStatusRequest,
-	ResetVideoStatusResponse,
+	UpdateVideoStatusRequest,
+	UpdateVideoStatusResponse,
 	ApiError
 } from './types';
 
@@ -162,11 +162,11 @@ class ApiClient {
 	 * @param id 视频 ID
 	 * @param request 重置请求参数
 	 */
-	async resetVideoStatus(
+	async updateVideoStatus(
 		id: number,
-		request: ResetVideoStatusRequest
-	): Promise<ApiResponse<ResetVideoStatusResponse>> {
-		return this.post<ResetVideoStatusResponse>(`/videos/${id}/reset-status`, request);
+		request: UpdateVideoStatusRequest
+	): Promise<ApiResponse<UpdateVideoStatusResponse>> {
+		return this.post<UpdateVideoStatusResponse>(`/videos/${id}/update-status`, request);
 	}
 }
 
@@ -203,8 +203,8 @@ export const api = {
 	/**
 	 * 重置视频状态位
 	 */
-	resetVideoStatus: (id: number, request: ResetVideoStatusRequest) =>
-		apiClient.resetVideoStatus(id, request),
+	updateVideoStatus: (id: number, request: UpdateVideoStatusRequest) =>
+		apiClient.updateVideoStatus(id, request),
 
 	/**
 	 * 设置认证 token

--- a/web/src/lib/components/status-editor.svelte
+++ b/web/src/lib/components/status-editor.svelte
@@ -9,14 +9,14 @@
 		SheetTitle
 	} from '$lib/components/ui/sheet/index.js';
 	import StatusTaskCard from './status-task-card.svelte';
-	import type { VideoInfo, PageInfo, StatusUpdate, ResetVideoStatusRequest } from '$lib/types';
+	import type { VideoInfo, PageInfo, StatusUpdate, UpdateVideoStatusRequest } from '$lib/types';
 	import { toast } from 'svelte-sonner';
 
 	export let open = false;
 	export let video: VideoInfo;
 	export let pages: PageInfo[] = [];
 	export let loading = false;
-	export let onsubmit: (request: ResetVideoStatusRequest) => void;
+	export let onsubmit: (request: UpdateVideoStatusRequest) => void;
 
 	// 视频任务名称（与后端 VideoStatus 对应）
 	const videoTaskNames = ['视频封面', '视频信息', 'UP主头像', 'UP主信息', '分P下载'];
@@ -109,8 +109,8 @@
 		return hasVideoChanges() || hasPageChanges();
 	}
 
-	function buildRequest(): ResetVideoStatusRequest {
-		const request: ResetVideoStatusRequest = {};
+	function buildRequest(): UpdateVideoStatusRequest {
+		const request: UpdateVideoStatusRequest = {};
 
 		// 构建视频状态更新
 		if (hasVideoChanges()) {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -91,13 +91,13 @@ export interface PageStatusUpdate {
 }
 
 // 重置视频状态请求类型
-export interface ResetVideoStatusRequest {
+export interface UpdateVideoStatusRequest {
 	video_updates?: StatusUpdate[];
 	page_updates?: PageStatusUpdate[];
 }
 
 // 重置视频状态响应类型
-export interface ResetVideoStatusResponse {
+export interface UpdateVideoStatusResponse {
 	success: boolean;
 	video: VideoInfo;
 	pages: PageInfo[];

--- a/web/src/routes/video/[id]/+page.svelte
+++ b/web/src/routes/video/[id]/+page.svelte
@@ -4,7 +4,7 @@
 	import { onMount } from 'svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import api from '$lib/api';
-	import type { ApiError, VideoResponse, ResetVideoStatusRequest } from '$lib/types';
+	import type { ApiError, VideoResponse, UpdateVideoStatusRequest } from '$lib/types';
 	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
 	import EditIcon from '@lucide/svelte/icons/edit';
 	import { setBreadcrumb } from '$lib/stores/breadcrumb';
@@ -60,12 +60,12 @@
 		loadVideoDetail();
 	}
 
-	async function handleStatusEditorSubmit(request: ResetVideoStatusRequest) {
+	async function handleStatusEditorSubmit(request: UpdateVideoStatusRequest) {
 		if (!videoData) return;
 
 		statusEditorLoading = true;
 		try {
-			const result = await api.resetVideoStatus(videoData.video.id, request);
+			const result = await api.updateVideoStatus(videoData.video.id, request);
 			const data = result.data;
 
 			if (data.success) {


### PR DESCRIPTION
分析了一下，swagger-ui 在 release build 中引入了 10M+ 的二进制体积，有点太过头了。自己 fork 魔改了一下 [rust-embed-for-web](https://github.com/amtoaer/rust-embed-for-web) 和 [utoipa](https://github.com/amtoaer/utoipa)，支持了前端资源的 precompress。

这样一方面程序内需要嵌入的二进制文件减小了，另一方面由于浏览器支持 content encoding，后端不需要在托管时自行解压，而是可以直接传递 precompress 的文件并附加 content encoding 的 header，交由浏览器自动处理。

唯一的麻烦是有些前端资源（如 swagger-ui 的 swagger-initializer.js） 需要后端对 placeholder 进行替换后再展示，这种文件必须保留原始内容，否则压缩后 placeholder 就消失了。费了点事，给 rust-embed-for-web 添加了 preserve_source_except 搞了手曲线救国。

压缩算法选择的是 [brotli](https://developer.mozilla.org/en-US/docs/Glossary/Brotli_compression)，现代浏览器应该都已经在几年前做了支持，不会有明显兼容性问题。

实测修改后二进制体积由 26M 变为了 16M。