### PR TITLE
视频源管理页面排序以及header设值部分的修改

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,7 @@ dependencies = [
  "dashmap",
  "dirs",
  "enum_dispatch",
+ "fake_user_agent",
  "float-ord",
  "futures",
  "git2",
@@ -1231,10 +1232,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.0.2"
+name = "fake_user_agent"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "913d317e38c6959fc258642eab72be85e99162a5fd19ca6c7b83c0c3c911d2f1"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "finl_unicode"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ cow-utils = "0.1.3"
 dashmap = "6.1.0"
 dirs = "6.0.0"
 enum_dispatch = "0.3.13"
+fake_user_agent = "0.2.2"
 float-ord = "0.3.2"
 futures = "0.3.31"
 git2 = { version = "0.20.2", features = [], default-features = false }

--- a/crates/bili_sync/Cargo.toml
+++ b/crates/bili_sync/Cargo.toml
@@ -24,6 +24,7 @@ cow-utils = { workspace = true }
 dashmap = { workspace = true }
 dirs = { workspace = true }
 enum_dispatch = { workspace = true }
+fake_user_agent.workspace = true
 float-ord = { workspace = true }
 futures = { workspace = true }
 handlebars = { workspace = true }

--- a/crates/bili_sync/src/bilibili/client.rs
+++ b/crates/bili_sync/src/bilibili/client.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use anyhow::Result;
+use fake_user_agent::get_chrome_rua;
 use leaky_bucket::RateLimiter;
 use reqwest::{Method, header};
 use sea_orm::DatabaseConnection;
@@ -17,12 +18,7 @@ impl Client {
     pub fn new() -> Self {
         // 正常访问 api 所必须的 header，作为默认 header 添加到每个请求中
         let mut headers = header::HeaderMap::new();
-        headers.insert(
-            header::USER_AGENT,
-            header::HeaderValue::from_static(
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
-            ),
-        );
+        headers.insert(header::USER_AGENT, header::HeaderValue::from_static(get_chrome_rua()));
         headers.insert(
             header::REFERER,
             header::HeaderValue::from_static("https://www.bilibili.com"),

--- a/web/src/routes/video-sources/+page.svelte
+++ b/web/src/routes/video-sources/+page.svelte
@@ -132,6 +132,9 @@
 			extendedSource.type = tabValue;
 			extendedSource.originalIndex = originalIndex;
 			return extendedSource;
+		}).sort((a, b) => {
+			// 按字典顺序排序
+			return a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' });
 		});
 	}
 


### PR DESCRIPTION
视频源管理页面中举例来说现在是这样排序

- 11_abc
- 1_abc
- 2_abc

加上排序后则是

- 1_abc
- 2_abc
- 11_abc