### PR TITLE
fix: 修复 sysinfo 初始值偶尔异常偏高的问题

### DIFF
--- a/crates/bili_sync/src/api/routes/ws/mod.rs
+++ b/crates/bili_sync/src/api/routes/ws/mod.rs
@@ -19,7 +19,6 @@ use sysinfo::{
     get_current_pid,
 };
 use tokio::sync::mpsc;
-use tokio::time::MissedTickBehavior;
 use tokio::{pin, select};
 use tokio_stream::wrappers::{BroadcastStream, WatchStream};
 use tokio_util::future::FutureExt;


### PR DESCRIPTION
偶尔飘到 0.4 比较奇怪，可能是初始部分时间间隔过短？还是先改回之前的逻辑。