### PR TITLE
fix: 修复从 2.6.0 以下版本直接升级的行为错误

### DIFF
--- a/crates/bili_sync/src/config/versioned_config.rs
+++ b/crates/bili_sync/src/config/versioned_config.rs
@@ -6,7 +6,7 @@ use sea_orm::DatabaseConnection;
 use tokio::sync::{OnceCell, watch};
 
 use crate::bilibili::Credential;
-use crate::config::{CONFIG_DIR, Config};
+use crate::config::Config;
 
 static VERSIONED_CONFIG: OnceCell<VersionedConfig> = OnceCell::const_new();
 
@@ -26,14 +26,6 @@ impl VersionedConfig {
                     Some(Ok(config)) => config,
                     Some(Err(e)) => bail!("解析数据库配置失败： {}", e),
                     None => {
-                        if CONFIG_DIR.join("config.toml").exists() {
-                            // 数据库中没有配置，但旧版配置文件存在，说明是从 2.6.0 之前的版本直接升级的
-                            bail!(
-                                "当前版本已移除配置文件的迁移逻辑，不再支持从配置文件加载配置。\n\
-                            如果你正在运行 2.6.0 之前的版本，请先升级至 2.6.x 或 2.7.x，\n\
-                            启动时会自动将配置文件迁移至数据库，然后再升级至最新版本。"
-                            );
-                        }
                         let config = Config::default();
                         warn!(
                             "生成 auth_token：{}，可使用该 token 登录 web UI，该信息仅在首次运行时打印",

--- a/crates/bili_sync/src/database.rs
+++ b/crates/bili_sync/src/database.rs
@@ -1,11 +1,11 @@
 use std::path::Path;
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use bili_sync_migration::{Migrator, MigratorTrait};
 use sea_orm::sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqliteSynchronous};
 use sea_orm::sqlx::{ConnectOptions as SqlxConnectOptions, Sqlite};
-use sea_orm::{ConnectOptions, Database, DatabaseConnection, SqlxSqliteConnector};
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection, SqlxSqliteConnector, Statement};
 
 fn database_url(path: &Path) -> String {
     format!("sqlite://{}?mode=rwc", path.to_string_lossy())
@@ -38,6 +38,19 @@ async fn migrate_database(database_url: &str) -> Result<()> {
     // 注意此处使用内部构造的 DatabaseConnection，而不是通过 database_connection() 获取
     // 这是因为使用多个连接的 Connection 会导致奇怪的迁移顺序问题，而使用默认的连接选项不会
     let connection = Database::connect(database_url).await?;
+    // 避免 https://github.com/amtoaer/bili-sync/issues/571 问题，迁移前根据 migration 确认当前版本
+    // 如果用户从 2.6.0 以下版本直接升级，migration 不满足需求，直接报错而不执行迁移
+    if connection
+        .query_one(Statement::from_string(
+            connection.get_database_backend(),
+            "SELECT 1 FROM seaql_migrations WHERE version = 'm20250613_043257_add_config';",
+        ))
+        .await
+        .is_ok_and(|res| res.is_none())
+    {
+        // 查询成功且结果为空，即没有 m20250613_043257_add_config，说明版本低于 2.6.0
+        bail!("该版本仅支持从 2.6.x 以上的版本升级，请先升级至 2.6.x 或 2.7.x 完成配置迁移，再升级至最新版本。");
+    }
     Ok(Migrator::up(&connection, None).await?)
 }
 


### PR DESCRIPTION
如果用户没有看 release note，直接从 2.6.0 版本以下升级，正确的行为应该是直接报错，不产生副作用。

但上次变更将 config 移动到了数据库中，config 的检查时机移动到了数据库迁移之后，这样会导致从 2.6.0 版本以下升级时数据库发生迁移，但配置文件保持原样，导致用户既没办法用回老版本也没办法使用新版本，需要手动介入恢复数据库，参见 #571
。

修复办法是将版本检查提前到迁移运行之前，目前的写法是根据已经运行的 migration 判断版本，测试通过。