### PR TITLE
fix: 修复并行下载未正确触发的问题，根据文件是否为流做不同处理

### DIFF
--- a/crates/bili_sync/src/downloader.rs
+++ b/crates/bili_sync/src/downloader.rs
@@ -308,7 +308,7 @@ mod tests {
         VersionedConfig::init_for_test(&setup_database(Path::new("./test.sqlite")).await?).await?;
         let config = VersionedConfig::get().read();
         let client = BiliClient::new();
-        let video = Video::new(&client, "BV19WBFBnEqn".to_owned(), &config.credential);
+        let video = Video::new(&client, "BV1QJmaYKEv4".to_owned(), &config.credential);
         let pages = video.get_pages().await.expect("failed to get pages");
         let first_page = pages.into_iter().next().expect("no page found");
         let mut page_analyzer = video


### PR DESCRIPTION
在上个 https://github.com/amtoaer/bili-sync/pull/579 修复中，我将 head 请求换成了带有 range 头的 get 请求，后续逻辑没有做任何修改，虽然测试下载通过，但其实会导致并行下载无法正确触发。

具体来说，当请求方法为 get 时，b 站的流不会返回 accept-range 头，而是仅包含一个 content-range 头，内容为 `bytes 0-0/{file_size}`，但在原有代码逻辑中发现没有 accept-range 头就直接 fallback 到串行下载了。

此外，为其它类型的资源使用这种不标准的探测逻辑也不太合适，尤其是在服务器不支持分块的情况下，直接假设服务器支持分块而发起带有 range 头的 get 请求很可能会导致服务器返回整个文件，带来不必要的开销。

因此修改为根据下载类型做不同处理：
1. 对于流，默认服务器支持分块，使用带 range 头的 get 请求探测文件大小，如果返回码不是 206（说明不支持分块，应该不会有这种情况）则 fallback 到串行下载，否则从 content-range 头中提取文件总大小，后续正常走并行下载逻辑；
2. 对于非流，使用常规的 head 探测，如果没有 accept-range 头或 accept-range 头为 none 则 fallback 到串行下载，否则从 content-length 头中获取文件总大小，后续正常走并行下载逻辑。 