### PR TITLE
feat: 支持搜索关注的 UP 主

### DIFF
--- a/crates/bili_sync/src/api/request.rs
+++ b/crates/bili_sync/src/api/request.rs
@@ -82,6 +82,7 @@ pub struct FollowedCollectionsRequest {
 pub struct FollowedUppersRequest {
     pub page_num: Option<i32>,
     pub page_size: Option<i32>,
+    pub name: Option<String>,
 }
 
 #[derive(Deserialize, Validate)]

--- a/crates/bili_sync/src/api/routes/me/mod.rs
+++ b/crates/bili_sync/src/api/routes/me/mod.rs
@@ -153,7 +153,9 @@ pub async fn get_followed_uppers(
     let credential = &VersionedConfig::get().read().credential;
     let me = Me::new(bili_client.as_ref(), credential);
     let (page_num, page_size) = (params.page_num.unwrap_or(1), params.page_size.unwrap_or(20));
-    let bili_uppers = me.get_followed_uppers(page_num, page_size).await?;
+    let bili_uppers = me
+        .get_followed_uppers(page_num, page_size, params.name.as_deref())
+        .await?;
 
     let bili_uid: Vec<_> = bili_uppers.list.iter().map(|upper| upper.mid).collect();
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -199,11 +199,13 @@ class ApiClient {
 
 	async getFollowedUppers(
 		pageNum?: number,
-		pageSize?: number
+		pageSize?: number,
+		name?: string
 	): Promise<ApiResponse<UppersResponse>> {
 		const params = {
 			page_num: pageNum,
-			page_size: pageSize
+			page_size: pageSize,
+			name: name
 		};
 		return this.get<UppersResponse>('/me/uppers', params as Record<string, unknown>);
 	}
@@ -294,8 +296,8 @@ const api = {
 	getCreatedFavorites: () => apiClient.getCreatedFavorites(),
 	getFollowedCollections: (pageNum?: number, pageSize?: number) =>
 		apiClient.getFollowedCollections(pageNum, pageSize),
-	getFollowedUppers: (pageNum?: number, pageSize?: number) =>
-		apiClient.getFollowedUppers(pageNum, pageSize),
+	getFollowedUppers: (pageNum?: number, pageSize?: number, name?: string) =>
+		apiClient.getFollowedUppers(pageNum, pageSize, name),
 	insertFavorite: (request: InsertFavoriteRequest) => apiClient.insertFavorite(request),
 	insertCollection: (request: InsertCollectionRequest) => apiClient.insertCollection(request),
 	insertSubmission: (request: InsertSubmissionRequest) => apiClient.insertSubmission(request),

--- a/web/src/routes/me/uppers/+page.svelte
+++ b/web/src/routes/me/uppers/+page.svelte
@@ -3,6 +3,7 @@
 	import { toast } from 'svelte-sonner';
 	import SubscriptionCard from '$lib/components/subscription-card.svelte';
 	import Pagination from '$lib/components/pagination.svelte';
+	import SearchBar from '$lib/components/search-bar.svelte';
 	import { setBreadcrumb } from '$lib/stores/breadcrumb';
 	import api from '$lib/api';
 	import type { Followed, ApiError } from '$lib/types';
@@ -11,13 +12,14 @@
 	let totalCount = 0;
 	let currentPage = 0;
 	let loading = false;
+	let searchQuery = '';
 
 	const pageSize = 50;
 
-	async function loadUppers(page: number = 0) {
+	async function loadUppers(page: number = 0, name?: string) {
 		loading = true;
 		try {
-			const response = await api.getFollowedUppers(page + 1, pageSize); // API 使用 1 基索引
+			const response = await api.getFollowedUppers(page + 1, pageSize, name || undefined); // API 使用 1 基索引
 			uppers = response.data.uppers;
 			totalCount = response.data.total;
 		} catch (error) {
@@ -32,12 +34,18 @@
 
 	function handleSubscriptionSuccess() {
 		// 重新加载数据以获取最新状态
-		loadUppers(currentPage);
+		loadUppers(currentPage, searchQuery);
 	}
 
 	async function handlePageChange(page: number) {
 		currentPage = page;
-		await loadUppers(page);
+		await loadUppers(page, searchQuery);
+	}
+
+	async function handleSearch(query: string) {
+		searchQuery = query;
+		currentPage = 0;
+		await loadUppers(0, query);
 	}
 
 	onMount(async () => {
@@ -53,6 +61,10 @@
 </svelte:head>
 
 <div>
+	<div class="mb-4 flex items-center justify-between">
+		<SearchBar placeholder="搜索 UP 主.." value={searchQuery} onSearch={handleSearch}></SearchBar>
+	</div>
+
 	<div class="mb-6 flex items-center justify-between">
 		<div class="flex items-center gap-6">
 			{#if !loading}


### PR DESCRIPTION
close #455

看了看并列的另外两个功能：
+ 收藏夹 API 不支持分页，可以直接用浏览器的搜索；
+ 收藏的合集、列表 API 支持分页但不支持搜索，没办法正确实现搜索功能。

因此只实现了 UP 主的搜索。
