### PR TITLE
feat: bind_address 绑定失败后尝试 fallback 到默认地址，避免无法启动 web 服务

### DIFF
--- a/crates/bili_sync/src/config/default.rs
+++ b/crates/bili_sync/src/config/default.rs
@@ -13,6 +13,6 @@ pub(super) fn default_auth_token() -> String {
         .collect()
 }
 
-pub(super) fn default_bind_address() -> String {
+pub(crate) fn default_bind_address() -> String {
     "0.0.0.0:12345".to_string()
 }

--- a/crates/bili_sync/src/config/mod.rs
+++ b/crates/bili_sync/src/config/mod.rs
@@ -8,6 +8,7 @@ mod versioned_config;
 
 pub use crate::config::args::{ARGS, version};
 pub use crate::config::current::{CONFIG_DIR, Config};
+pub(crate) use crate::config::default::default_bind_address;
 pub use crate::config::handlebar::TEMPLATE;
 pub use crate::config::item::{ConcurrentDownloadLimit, NFOTimeType, PathSafeTemplate, RateLimit, Trigger};
 pub use crate::config::versioned_cache::VersionedCache;


### PR DESCRIPTION
close #587
