### PR TITLE
chore: 指定项目 Rust 版本为 1.93.0，调整 CI 确保使用的 Rust 版本与 rust-toolchain.yaml 一致

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -75,17 +75,18 @@ jobs:
         with:
           name: web-build
           path: web/build
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-      - name: Install musl-tools
-        run: sudo apt-get update --yes && sudo apt-get install --yes musl-tools
-        if: contains(matrix.platform.target, 'musl')
+      - name: Read Toolchain Version
+        uses: SebRollen/toml-action@v1.2.0
+        id: read_rust_toolchain
+        with:
+          file: rust-toolchain.toml
+          field: toolchain.channel
       - name: Build binary
-        uses: houseabsolute/actions-rust-cross@v0
+        uses: houseabsolute/actions-rust-cross@v1
         with:
           command: build
           target: ${{ matrix.platform.target }}
-          toolchain: stable
+          toolchain: ${{ steps.read_rust_toolchain.outputs.value }}
           args: "--locked --release"
           strip: true
       - name: Package as archive

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - run: rustup default stable && rustup component add clippy && rustup component add rustfmt --toolchain nightly
+      - run: rustup install && rustup component add rustfmt --toolchain nightly
 
       - name: Cache dependencies
         uses: swatinem/rust-cache@v2

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.93.0"
+components = ["clippy"]


### PR DESCRIPTION
rust 1.93.0 将捆绑的 musl 更新到了 1.2.5 版本，据 Release Notes 所说：
> For the Rust ecosystem, the primary motivation for this update is to receive major improvements to musl's DNS resolver which shipped in 1.2.4 and received bug fixes in 1.2.5. **When using musl targets for static linking, this should make portable Linux binaries that do networking more reliable, particularly in the face of large DNS records and recursive nameservers**.
>
> 对于 Rust 生态系统而言，此次更新的主要动力在于引入 musl DNS 解析器的重大改进——这些改进最初在 1.2.4 版本发布，并在 1.2.5 版本中进行了错误修复。**当使用 musl 目标进行静态链接时，这些改进将使处理网络请求的可移植 Linux 二进制文件更加可靠，尤其是在面对大型 DNS 记录和递归域名服务器的情况下**。

此外略微调整了一下 CI 流程，包括：
1. 移除已在 `rust-cross` action 中包括的 musl-tools 安装与 rust 依赖缓存；
2. 添加 toolchain 版本读取，确保 CI 遵循 rust-toolchain.yaml 锁定。