### PR TITLE
fix: 修复某些收藏夹视频的 valid 判断

### DIFF
--- a/crates/bili_sync/src/api/response.rs
+++ b/crates/bili_sync/src/api/response.rs
@@ -73,6 +73,7 @@ pub struct VideoInfo {
     pub bvid: String,
     pub name: String,
     pub upper_name: String,
+    pub valid: bool,
     pub should_download: bool,
     #[serde(serialize_with = "serde_video_download_status")]
     pub download_status: u32,

--- a/crates/bili_sync/src/api/routes/videos/mod.rs
+++ b/crates/bili_sync/src/api/routes/videos/mod.rs
@@ -174,6 +174,7 @@ pub async fn clear_and_reset_video_status(
     let mut video_info = video_info.into_active_model();
     video_info.single_page = Set(None);
     video_info.download_status = Set(0);
+    video_info.valid = Set(true);
     let video_info = video_info.update(&txn).await?;
     page::Entity::delete_many()
         .filter(page::Column::VideoId.eq(id))
@@ -193,6 +194,7 @@ pub async fn clear_and_reset_video_status(
             bvid: video_info.bvid,
             name: video_info.name,
             upper_name: video_info.upper_name,
+            valid: video_info.valid,
             should_download: video_info.should_download,
             download_status: video_info.download_status,
         },

--- a/crates/bili_sync/src/utils/convert.rs
+++ b/crates/bili_sync/src/utils/convert.rs
@@ -10,6 +10,7 @@ impl VideoInfo {
         let default = bili_sync_entity::video::ActiveModel {
             id: NotSet,
             created_at: NotSet,
+            should_download: NotSet,
             // 此处不使用 ActiveModel::default() 是为了让其它字段有默认值
             ..bili_sync_entity::video::Model::default().into_active_model()
         };
@@ -49,7 +50,7 @@ impl VideoInfo {
                 pubtime: Set(pubtime.naive_utc()),
                 favtime: Set(fav_time.naive_utc()),
                 download_status: Set(0),
-                valid: Set(attr == 0),
+                valid: Set(attr == 0 || attr == 4),
                 upper_id: Set(upper.mid),
                 upper_name: Set(upper.name),
                 upper_face: Set(upper.face),

--- a/web/src/lib/components/video-card.svelte
+++ b/web/src/lib/components/video-card.svelte
@@ -57,11 +57,16 @@
 
 	function getOverallStatus(
 		downloadStatus: number[],
-		shouldDownload: boolean
+		shouldDownload: boolean,
+		valid: boolean
 	): {
 		text: string;
 		style: string;
 	} {
+		if (!valid) {
+			// 视频属性表明已失效，或由于各种条件判断（充电视频等）判定为无效的情况
+			return { text: '无效', style: 'bg-gray-100 text-gray-700' };
+		}
 		if (!shouldDownload) {
 			// 被过滤规则排除，显示为“跳过”
 			return { text: '跳过', style: 'bg-gray-100 text-gray-700' };
@@ -90,7 +95,7 @@
 		return defaultTaskNames[index] || `任务${index + 1}`;
 	}
 
-	$: overallStatus = getOverallStatus(video.download_status, video.should_download);
+	$: overallStatus = getOverallStatus(video.download_status, video.should_download, video.valid);
 	$: completed = video.download_status.filter((status) => status === 7).length;
 	$: total = video.download_status.length;
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -31,6 +31,7 @@ export interface VideoInfo {
 	bvid: string;
 	name: string;
 	upper_name: string;
+	valid: boolean;
 	should_download: boolean;
 	download_status: [number, number, number, number, number];
 }


### PR DESCRIPTION
close #647

程序会在检查新视频的时候基于一些字段进行视频是否有效（valid）的基础判断，如果 valid 为 true 才会进入后续的视频详情填充。在视频详情填充环节会获取视频详情，根据详细信息进行更细致的 valid 判断，并使用过滤规则判断是否应该下载（should_download）。

问题中的表现由两部分错误构成：
1. 检查新视频设置 valid 时，过去 bili-api-collect 的文档中说明视频 attr 字段为 0 表示视频有效，但实际上 issue 中的视频 attr 为 4 也是有效的；
2. 检查新视频时的基础判断认为 valid 为 false 时是不会进入后续的过滤规则评估的，因此用来表示过滤规则评估结果的 should_download 字段应该取默认值 true，但由于逻辑错误取成了 false，导致前端显示为 “跳过”。

该 PR 修复了这两个错误，并在前端额外加入了 valid 字段的状态显示，现在当 valid 为 false 时会将视频状态显示为“无效”。

此外，对于过去逻辑错误导致 valid 设置错误的情况，现在“清空重置”功能会将 valid 覆盖为 true，确保视频能够进入视频详情填充流程。