### PR TITLE
feat(config): 添加 `run_once` 参数和跳过下载视频文件开关

### DIFF
--- a/crates/bili_sync/src/config/args.rs
+++ b/crates/bili_sync/src/config/args.rs
@@ -9,6 +9,9 @@ pub static ARGS: LazyLock<Args> = LazyLock::new(Args::parse);
 #[derive(Parser)]
 #[command(name = "Bili-Sync", version = detail_version(), about, long_about = None)]
 pub struct Args {
+    #[arg(short, long, env = "RUN_ONCE")]
+    pub run_once: bool,
+
     #[arg(short, long, env = "SCAN_ONLY")]
     pub scan_only: bool,
 

--- a/crates/bili_sync/src/config/item.rs
+++ b/crates/bili_sync/src/config/item.rs
@@ -64,6 +64,8 @@ impl Default for ConcurrentLimit {
 pub struct SkipOption {
     pub no_poster: bool,
     pub no_video_nfo: bool,
+    #[serde(default)]
+    pub no_video: bool,
     pub no_upper: bool,
     pub no_danmaku: bool,
     pub no_subtitle: bool,

--- a/crates/bili_sync/src/main.rs
+++ b/crates/bili_sync/src/main.rs
@@ -22,7 +22,7 @@ use anyhow::{Context, Result, bail};
 use bilibili::BiliClient;
 use parking_lot::RwLock;
 use sea_orm::DatabaseConnection;
-use task::{http_server, video_downloader};
+use task::{download_once, http_server, video_downloader};
 use tokio::process::Command;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
@@ -42,6 +42,24 @@ async fn main() {
             return;
         }
     };
+
+    if ARGS.run_once {
+        if let Err(e) = download_once(connection.clone(), bili_client.clone()).await {
+            error!("运行一次下载任务失败：{:#}", e);
+        }
+        // 运行一次模式：等待用户按键后退出，避免双击时窗口立即关闭
+        info!("已完成一次运行。按回车键退出...");
+        // 在 tokio 运行时中执行阻塞式 stdin 读取
+        let _ = tokio::task::spawn_blocking(|| {
+            use std::io::{self, Read};
+            let mut stdin = io::stdin();
+            // 尝试读取一行，若失败则直接返回
+            let mut _buf = String::new();
+            let _ = stdin.read_line(&mut _buf);
+        })
+        .await;
+        return;
+    }
 
     let token = CancellationToken::new();
     let tracker = TaskTracker::new();

--- a/crates/bili_sync/src/task/mod.rs
+++ b/crates/bili_sync/src/task/mod.rs
@@ -2,4 +2,4 @@ mod http_server;
 mod video_downloader;
 
 pub use http_server::http_server;
-pub use video_downloader::{DownloadTaskManager, TaskStatus, video_downloader};
+pub use video_downloader::{download_once, DownloadTaskManager, TaskStatus, video_downloader};

--- a/crates/bili_sync/src/task/video_downloader.rs
+++ b/crates/bili_sync/src/task/video_downloader.rs
@@ -17,6 +17,12 @@ use crate::workflow::process_video_source;
 
 static INSTANCE: OnceCell<DownloadTaskManager> = OnceCell::const_new();
 
+/// 运行一次下载任务并退出（不启动调度器 / Web UI）
+pub async fn download_once(connection: DatabaseConnection, bili_client: Arc<BiliClient>) -> Result<()> {
+    let mut config = VersionedConfig::get().snapshot();
+    download_video(&connection, &bili_client, &mut config).await
+}
+
 /// 启动周期下载视频的任务
 pub async fn video_downloader(connection: DatabaseConnection, bili_client: Arc<BiliClient>) -> Result<()> {
     let task_manager = DownloadTaskManager::init(connection, bili_client).await?;

--- a/crates/bili_sync/src/workflow.rs
+++ b/crates/bili_sync/src/workflow.rs
@@ -482,7 +482,13 @@ pub async fn download_page(
             cx
         ),
         // 下载分页视频
-        fetch_page_video(separate_status[1], video_model, &page_info, &video_path, cx),
+        fetch_page_video(
+            separate_status[1] && !cx.config.skip_option.no_video,
+            video_model,
+            &page_info,
+            &video_path,
+            cx,
+        ),
         // 生成分页视频信息的 nfo
         generate_page_nfo(
             separate_status[2] && !cx.config.skip_option.no_video_nfo,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -265,6 +265,7 @@ export interface DanmakuOption {
 export interface SkipOption {
 	no_poster: boolean;
 	no_video_nfo: boolean;
+	no_video: boolean;
 	no_upper: boolean;
 	no_danmaku: boolean;
 	no_subtitle: boolean;

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -649,6 +649,10 @@
 							<Label for="skip-video-nfo">跳过视频 NFO</Label>
 						</div>
 						<div class="flex items-center space-x-2">
+							<Switch id="skip-video" bind:checked={formData.skip_option.no_video} />
+							<Label for="skip-video">跳过下载视频文件</Label>
+						</div>
+						<div class="flex items-center space-x-2">
 							<Switch id="skip-upper-info" bind:checked={formData.skip_option.no_upper} />
 							<Label for="skip-upper-info">跳过 Up 主头像、信息</Label>
 						</div>


### PR DESCRIPTION
在 `args.rs` 中添加了 `run_once` 参数，允许用户通过命令行或环境变量指定是否只运行一次下载任务。

在 `item.rs` 中添加了 `no_video` 参数到 `SkipOption` 结构体，使用 `serde(default)` 属性默认值为 `false`，允许用户选择是否跳过下载视频文件。

在 `main.rs` 中根据 `ARGS.run_once` 参数的值决定是否执行一次性的下载任务。如果 `run_once` 为 `true`，则调用 `download_once` 函数执行下载任务并退出程序，避免双击时窗口立即关闭。

在 `task/mod.rs` 中将 `download_once` 函数添加到 `pub use` 列表中，以便在其他模块中调用。

在 `video_downloader.rs` 中实现了一个新的 `download_once` 函数，该函数运行一次下载任务并退出，不启动调度器或 Web UI。

在 `workflow.rs` 中对 `fetch_page_video` 函数调用进行了调整，根据 `cx.config.skip_option.no_video` 的值来决定是否下载分页视频。

在 `types.ts` 中为 `SkipOption` 接口添加了 `no_video` 属性，允许前端传递跳过下载视频文件的设置。

在 `+page.svelte` 中为 `SkipOption` 添加了一个新的开关控件，允许用户在设置页面中选择是否跳过下载视频文件。