### PR TITLE
[codex] add download runtime stats to dashboard

### DIFF
--- a/crates/bili_sync/src/api/routes/ws/mod.rs
+++ b/crates/bili_sync/src/api/routes/ws/mod.rs
@@ -28,6 +28,7 @@ use uuid::Uuid;
 
 use crate::api::response::SysInfo;
 use crate::task::{DownloadTaskManager, TaskStatus};
+use crate::utils::download_stats::{DownloadStats, DownloadStatsManager};
 
 static WEBSOCKET_HANDLER: LazyLock<WebSocketHandler> = LazyLock::new(WebSocketHandler::new);
 
@@ -46,6 +47,7 @@ enum EventType {
     Logs,
     Tasks,
     SysInfo,
+    DownloadStats,
 }
 
 #[derive(Deserialize)]
@@ -61,6 +63,7 @@ enum ServerEvent {
     Logs(String),
     Tasks(TaskStatus),
     SysInfo(SysInfo),
+    DownloadStats(DownloadStats),
 }
 
 struct WebSocketHandler {
@@ -104,7 +107,7 @@ impl WebSocketHandler {
         // 日志和任务状态的处理本身就是由 stream 驱动的，可以直接为每个 ws 连接维护独立的任务处理器
         // 系统信息是服务端轮询然后推送的，如果单独维护会导致每个连接都独立轮询系统信息，造成不必要的浪费
         // 因此采用了全局的订阅者管理，所有连接共享同一个系统信息轮询任务
-        let (mut log_cancel, mut task_cancel) = (None, None);
+        let (mut log_cancel, mut task_cancel, mut download_stats_cancel) = (None, None, None);
         while let Some(Ok(msg)) = receiver.next().await {
             let Message::Text(text) = msg else {
                 continue;
@@ -143,6 +146,16 @@ impl WebSocketHandler {
                 ClientEvent::Unsubscribe(EventType::SysInfo) => {
                     self.remove_sysinfo_subscriber(uuid);
                 }
+                ClientEvent::Subscribe(EventType::DownloadStats) => {
+                    if download_stats_cancel.is_none() {
+                        download_stats_cancel = Some(self.new_download_stats_handler(tx.clone()));
+                    }
+                }
+                ClientEvent::Unsubscribe(EventType::DownloadStats) => {
+                    if let Some(cancel) = download_stats_cancel.take() {
+                        cancel.cancel();
+                    }
+                }
             }
         }
         // 连接关闭，清除仍然残留的任务
@@ -150,6 +163,9 @@ impl WebSocketHandler {
             cancel.cancel();
         }
         if let Some(cancel) = task_cancel {
+            cancel.cancel();
+        }
+        if let Some(cancel) = download_stats_cancel {
             cancel.cancel();
         }
         self.remove_sysinfo_subscriber(uuid);
@@ -214,6 +230,27 @@ impl WebSocketHandler {
                 while let Some(event) = stream.next().await {
                     if let Err(e) = tx.send(event).await {
                         error!("Failed to send task status: {:?}", e);
+                        break;
+                    }
+                }
+            }
+            .with_cancellation_token_owned(cancel_token.clone()),
+        );
+        cancel_token
+    }
+
+    fn new_download_stats_handler(&self, tx: mpsc::Sender<ServerEvent>) -> CancellationToken {
+        let cancel_token = CancellationToken::new();
+        tokio::spawn(
+            async move {
+                let mut interval = tokio::time::interval(Duration::from_secs(2));
+                loop {
+                    interval.tick().await;
+                    if tx
+                        .send(ServerEvent::DownloadStats(DownloadStatsManager::get().snapshot()))
+                        .await
+                        .is_err()
+                    {
                         break;
                     }
                 }

--- a/crates/bili_sync/src/downloader.rs
+++ b/crates/bili_sync/src/downloader.rs
@@ -8,16 +8,29 @@ use async_tempfile::TempFile;
 use futures::TryStreamExt;
 use reqwest::{Method, StatusCode, header};
 use tokio::fs::{self};
-use tokio::io::{AsyncSeekExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWrite, AsyncWriteExt};
 use tokio::process::Command;
 use tokio::task::JoinSet;
 use tokio_util::io::StreamReader;
 
 use crate::bilibili::{Client, ErrorForStatusExt};
 use crate::config::{ARGS, ConcurrentDownloadLimit};
+use crate::utils::download_stats::DownloadStatsManager;
 
 pub struct Downloader {
     client: Client,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DownloadStatsScope {
+    None,
+    Media,
+}
+
+impl DownloadStatsScope {
+    fn should_track_runtime(self) -> bool {
+        matches!(self, Self::Media)
+    }
 }
 
 impl Downloader {
@@ -28,9 +41,15 @@ impl Downloader {
         Self { client }
     }
 
-    pub async fn fetch(&self, url: &str, path: &Path, concurrent_download: &ConcurrentDownloadLimit) -> Result<()> {
+    pub async fn fetch(
+        &self,
+        url: &str,
+        path: &Path,
+        concurrent_download: &ConcurrentDownloadLimit,
+        stats_scope: DownloadStatsScope,
+    ) -> Result<()> {
         let mut temp_file = TempFile::new().await?;
-        self.fetch_internal(url, &mut temp_file, false, concurrent_download)
+        self.fetch_internal(url, &mut temp_file, false, concurrent_download, stats_scope)
             .await?;
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).await?;
@@ -48,8 +67,11 @@ impl Downloader {
         urls: &[&str],
         path: &Path,
         concurrent_download: &ConcurrentDownloadLimit,
+        stats_scope: DownloadStatsScope,
     ) -> Result<()> {
-        let temp_file = self.multi_fetch_internal(urls, true, concurrent_download).await?;
+        let temp_file = self
+            .multi_fetch_internal(urls, true, concurrent_download, stats_scope)
+            .await?;
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).await?;
         }
@@ -64,10 +86,11 @@ impl Downloader {
         audio_urls: &[&str],
         path: &Path,
         concurrent_download: &ConcurrentDownloadLimit,
+        stats_scope: DownloadStatsScope,
     ) -> Result<()> {
         let (video_temp_file, audio_temp_file) = tokio::try_join!(
-            self.multi_fetch_internal(video_urls, true, concurrent_download),
-            self.multi_fetch_internal(audio_urls, true, concurrent_download)
+            self.multi_fetch_internal(video_urls, true, concurrent_download, stats_scope),
+            self.multi_fetch_internal(audio_urls, true, concurrent_download, stats_scope)
         )?;
         let final_temp_file = TempFile::new().await?;
         let output = Command::new(ARGS.ffmpeg_path.as_deref().unwrap_or("ffmpeg"))
@@ -108,6 +131,7 @@ impl Downloader {
         urls: &[&str],
         is_stream: bool,
         concurrent_download: &ConcurrentDownloadLimit,
+        stats_scope: DownloadStatsScope,
     ) -> Result<TempFile> {
         if urls.is_empty() {
             bail!("no urls provided");
@@ -115,7 +139,7 @@ impl Downloader {
         let mut temp_file = TempFile::new().await?;
         for (idx, url) in urls.iter().enumerate() {
             match self
-                .fetch_internal(url, &mut temp_file, is_stream, concurrent_download)
+                .fetch_internal(url, &mut temp_file, is_stream, concurrent_download, stats_scope)
                 .await
             {
                 Ok(_) => return Ok(temp_file),
@@ -138,15 +162,20 @@ impl Downloader {
         file: &mut TempFile,
         is_stream: bool,
         concurrent_download: &ConcurrentDownloadLimit,
+        stats_scope: DownloadStatsScope,
     ) -> Result<()> {
         if concurrent_download.enable {
-            self.fetch_parallel(url, file, is_stream, concurrent_download).await
+            self.fetch_parallel(url, file, is_stream, concurrent_download, stats_scope)
+                .await
         } else {
-            self.fetch_serial(url, file).await
+            self.fetch_serial(url, file, stats_scope).await
         }
     }
 
-    async fn fetch_serial(&self, url: &str, file: &mut TempFile) -> Result<()> {
+    async fn fetch_serial(&self, url: &str, file: &mut TempFile, stats_scope: DownloadStatsScope) -> Result<()> {
+        let _fragment = stats_scope
+            .should_track_runtime()
+            .then(|| DownloadStatsManager::get().track_fragment());
         let resp = self
             .client
             .request(Method::GET, url, None)
@@ -155,7 +184,7 @@ impl Downloader {
             .error_for_status_ext()?;
         let expected = resp.header_content_length();
         let mut stream_reader = StreamReader::new(resp.bytes_stream().map_err(std::io::Error::other));
-        let received = tokio::io::copy(&mut stream_reader, file).await?;
+        let received = copy_counting(&mut stream_reader, file, stats_scope).await?;
         file.flush().await?;
         if let Some(expected) = expected {
             ensure!(
@@ -174,6 +203,7 @@ impl Downloader {
         file: &mut TempFile,
         is_stream: bool,
         concurrent_download: &ConcurrentDownloadLimit,
+        stats_scope: DownloadStatsScope,
     ) -> Result<()> {
         let (concurrency, threshold) = (concurrent_download.concurrency, concurrent_download.threshold);
         let file_size = if is_stream {
@@ -186,7 +216,7 @@ impl Downloader {
                 .await?
                 .error_for_status_ext()?;
             if resp.status() != StatusCode::PARTIAL_CONTENT {
-                return self.fetch_serial(url, file).await;
+                return self.fetch_serial(url, file, stats_scope).await;
             }
             resp.header_file_size()
         } else {
@@ -203,16 +233,16 @@ impl Downloader {
                 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept-Ranges#none
                 .is_none_or(|v| v.to_str().unwrap_or_default() == "none")
             {
-                return self.fetch_serial(url, file).await;
+                return self.fetch_serial(url, file, stats_scope).await;
             }
             resp.header_content_length()
         };
         let Some(file_size) = file_size else {
-            return self.fetch_serial(url, file).await;
+            return self.fetch_serial(url, file, stats_scope).await;
         };
         let chunk_size = file_size / concurrency as u64;
         if chunk_size < threshold {
-            return self.fetch_serial(url, file).await;
+            return self.fetch_serial(url, file, stats_scope).await;
         }
         file.set_len(file_size).await?;
         let mut tasks = JoinSet::new();
@@ -227,6 +257,9 @@ impl Downloader {
             let (url_clone, client_clone) = (url.clone(), self.client.clone());
             let mut file_clone = file.open_rw().await?;
             tasks.spawn(async move {
+                let _fragment = stats_scope
+                    .should_track_runtime()
+                    .then(|| DownloadStatsManager::get().track_fragment());
                 file_clone.seek(SeekFrom::Start(start)).await?;
                 let range_header = format!("bytes={}-{}", start, end);
                 let resp = client_clone
@@ -244,7 +277,7 @@ impl Downloader {
                     );
                 }
                 let mut stream_reader = StreamReader::new(resp.bytes_stream().map_err(std::io::Error::other));
-                let received = tokio::io::copy(&mut stream_reader, &mut file_clone).await?;
+                let received = copy_counting(&mut stream_reader, &mut file_clone, stats_scope).await?;
                 file_clone.flush().await?;
                 ensure!(
                     received == end - start + 1,
@@ -259,6 +292,26 @@ impl Downloader {
             res??;
         }
         Ok(())
+    }
+}
+
+async fn copy_counting<R, W>(reader: &mut R, writer: &mut W, stats_scope: DownloadStatsScope) -> std::io::Result<u64>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut buffer = vec![0; 64 * 1024];
+    let mut received = 0;
+    loop {
+        let n = reader.read(&mut buffer).await?;
+        if n == 0 {
+            return Ok(received);
+        }
+        writer.write_all(&buffer[..n]).await?;
+        received += n as u64;
+        if stats_scope.should_track_runtime() {
+            DownloadStatsManager::get().record_bytes(n as u64);
+        }
     }
 }
 
@@ -297,10 +350,17 @@ mod tests {
 
     use anyhow::Result;
 
+    use super::DownloadStatsScope;
     use crate::bilibili::{BestStream, BiliClient, Video};
     use crate::config::VersionedConfig;
     use crate::database::setup_database;
     use crate::downloader::Downloader;
+
+    #[test]
+    fn media_scope_is_the_only_scope_that_tracks_runtime_stats() {
+        assert!(!DownloadStatsScope::None.should_track_runtime());
+        assert!(DownloadStatsScope::Media.should_track_runtime());
+    }
 
     #[ignore = "only for manual test"]
     #[tokio::test(flavor = "multi_thread")]
@@ -336,6 +396,7 @@ mod tests {
                 &audio.urls(true),
                 Path::new("./output.mp4"),
                 &config.concurrent_limit.download,
+                DownloadStatsScope::Media,
             )
             .await
             .expect("failed to download video");

--- a/crates/bili_sync/src/task/video_downloader.rs
+++ b/crates/bili_sync/src/task/video_downloader.rs
@@ -11,6 +11,7 @@ use tokio_cron_scheduler::{Job, JobScheduler};
 use crate::adapter::VideoSource;
 use crate::bilibili::{self, BiliClient, BiliError};
 use crate::config::{ARGS, Config, TEMPLATE, Trigger, VersionedConfig};
+use crate::utils::download_stats::DownloadStatsManager;
 use crate::utils::model::get_enabled_video_sources;
 use crate::utils::notify::error_and_notify;
 use crate::workflow::process_video_source;
@@ -276,6 +277,7 @@ impl DownloadTaskManager {
                     last_finish: None,
                     next_run: None,
                 });
+                DownloadStatsManager::get().reset_task();
                 info!("开始执行本轮视频下载任务..");
                 let mut config = VersionedConfig::get().snapshot();
                 match download_video(&cx.connection, &cx.bili_client, &mut config).await {

--- a/crates/bili_sync/src/utils/download_stats.rs
+++ b/crates/bili_sync/src/utils/download_stats.rs
@@ -1,0 +1,185 @@
+use std::collections::VecDeque;
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use parking_lot::Mutex;
+use serde::Serialize;
+
+const SPEED_WINDOW_MILLIS: i64 = 10_000;
+
+static DOWNLOAD_STATS: LazyLock<DownloadStatsManager> = LazyLock::new(DownloadStatsManager::new);
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct DownloadStats {
+    pub timestamp: i64,
+    pub current_speed_bytes_per_sec: u64,
+    pub task_downloaded_bytes: u64,
+    pub active_videos: u64,
+    pub active_pages: u64,
+    pub active_fragments: u64,
+}
+
+#[derive(Debug, Default)]
+pub struct DownloadStatsManager {
+    task_downloaded_bytes: AtomicU64,
+    active_videos: AtomicU64,
+    active_pages: AtomicU64,
+    active_fragments: AtomicU64,
+    recent_bytes: Mutex<VecDeque<ByteSample>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ByteSample {
+    timestamp: i64,
+    bytes: u64,
+}
+
+impl DownloadStatsManager {
+    pub fn get() -> &'static Self {
+        &DOWNLOAD_STATS
+    }
+
+    fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn reset_task(&self) {
+        self.task_downloaded_bytes.store(0, Ordering::Relaxed);
+        self.recent_bytes.lock().clear();
+    }
+
+    pub fn record_bytes(&self, bytes: u64) {
+        self.record_bytes_at(chrono::Utc::now().timestamp_millis(), bytes);
+    }
+
+    pub fn track_video(&self) -> DownloadStatsGuard<'_> {
+        self.active_videos.fetch_add(1, Ordering::Relaxed);
+        DownloadStatsGuard {
+            counter: &self.active_videos,
+        }
+    }
+
+    pub fn track_page(&self) -> DownloadStatsGuard<'_> {
+        self.active_pages.fetch_add(1, Ordering::Relaxed);
+        DownloadStatsGuard {
+            counter: &self.active_pages,
+        }
+    }
+
+    pub fn track_fragment(&self) -> DownloadStatsGuard<'_> {
+        self.active_fragments.fetch_add(1, Ordering::Relaxed);
+        DownloadStatsGuard {
+            counter: &self.active_fragments,
+        }
+    }
+
+    pub fn snapshot(&self) -> DownloadStats {
+        self.snapshot_at(chrono::Utc::now().timestamp_millis())
+    }
+
+    fn record_bytes_at(&self, timestamp: i64, bytes: u64) {
+        if bytes == 0 {
+            return;
+        }
+        self.task_downloaded_bytes.fetch_add(bytes, Ordering::Relaxed);
+        let mut recent_bytes = self.recent_bytes.lock();
+        recent_bytes.push_back(ByteSample { timestamp, bytes });
+        Self::prune_old_samples(&mut recent_bytes, timestamp);
+    }
+
+    fn snapshot_at(&self, timestamp: i64) -> DownloadStats {
+        let current_speed_bytes_per_sec = {
+            let mut recent_bytes = self.recent_bytes.lock();
+            Self::prune_old_samples(&mut recent_bytes, timestamp);
+            recent_bytes.iter().map(|sample| sample.bytes).sum::<u64>() / (SPEED_WINDOW_MILLIS as u64 / 1000)
+        };
+        DownloadStats {
+            timestamp,
+            current_speed_bytes_per_sec,
+            task_downloaded_bytes: self.task_downloaded_bytes.load(Ordering::Relaxed),
+            active_videos: self.active_videos.load(Ordering::Relaxed),
+            active_pages: self.active_pages.load(Ordering::Relaxed),
+            active_fragments: self.active_fragments.load(Ordering::Relaxed),
+        }
+    }
+
+    fn prune_old_samples(recent_bytes: &mut VecDeque<ByteSample>, now: i64) {
+        while recent_bytes
+            .front()
+            .is_some_and(|sample| sample.timestamp < now - SPEED_WINDOW_MILLIS)
+        {
+            recent_bytes.pop_front();
+        }
+    }
+
+    #[cfg(test)]
+    fn new_for_test() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug)]
+pub struct DownloadStatsGuard<'a> {
+    counter: &'a AtomicU64,
+}
+
+impl Drop for DownloadStatsGuard<'_> {
+    fn drop(&mut self) {
+        self.counter.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_reset_keeps_current_gauges_and_clears_task_bytes() {
+        let stats = DownloadStatsManager::new_for_test();
+        let _video = stats.track_video();
+        let _page = stats.track_page();
+        let _fragment = stats.track_fragment();
+
+        stats.record_bytes_at(10_000, 1024);
+        stats.reset_task();
+
+        let snapshot = stats.snapshot_at(10_000);
+        assert_eq!(snapshot.task_downloaded_bytes, 0);
+        assert_eq!(snapshot.active_videos, 1);
+        assert_eq!(snapshot.active_pages, 1);
+        assert_eq!(snapshot.active_fragments, 1);
+    }
+
+    #[test]
+    fn speed_uses_recent_byte_samples() {
+        let stats = DownloadStatsManager::new_for_test();
+
+        stats.record_bytes_at(1_000, 1024);
+        stats.record_bytes_at(2_000, 1024);
+        stats.record_bytes_at(12_500, 4096);
+
+        let snapshot = stats.snapshot_at(12_500);
+        assert_eq!(snapshot.current_speed_bytes_per_sec, 409);
+        assert_eq!(snapshot.task_downloaded_bytes, 6144);
+    }
+
+    #[test]
+    fn active_guards_decrement_on_drop() {
+        let stats = DownloadStatsManager::new_for_test();
+        {
+            let _video = stats.track_video();
+            let _page = stats.track_page();
+            let _fragment = stats.track_fragment();
+
+            let snapshot = stats.snapshot_at(1_000);
+            assert_eq!(snapshot.active_videos, 1);
+            assert_eq!(snapshot.active_pages, 1);
+            assert_eq!(snapshot.active_fragments, 1);
+        }
+
+        let snapshot = stats.snapshot_at(1_000);
+        assert_eq!(snapshot.active_videos, 0);
+        assert_eq!(snapshot.active_pages, 0);
+        assert_eq!(snapshot.active_fragments, 0);
+    }
+}

--- a/crates/bili_sync/src/utils/mod.rs
+++ b/crates/bili_sync/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod convert;
 pub mod download_context;
+pub mod download_stats;
 pub mod filenamify;
 pub mod format_arg;
 pub mod model;

--- a/crates/bili_sync/src/workflow.rs
+++ b/crates/bili_sync/src/workflow.rs
@@ -16,10 +16,11 @@ use tokio::sync::Semaphore;
 use crate::adapter::{VideoSource, VideoSourceEnum};
 use crate::bilibili::{BestStream, BiliClient, BiliError, Dimension, PageInfo, Video, VideoInfo};
 use crate::config::{ARGS, Config, PathSafeTemplate};
-use crate::downloader::Downloader;
+use crate::downloader::{DownloadStatsScope, Downloader};
 use crate::error::ExecutionStatus;
 use crate::notifier::DownloadNotifyInfo;
 use crate::utils::download_context::DownloadContext;
+use crate::utils::download_stats::DownloadStatsManager;
 use crate::utils::format_arg::{page_format_args, video_format_args};
 use crate::utils::model::{
     create_pages, create_videos, filter_unfilled_videos, filter_unhandled_video_pages, update_pages_model,
@@ -239,6 +240,7 @@ pub async fn download_video_pages(
     cx: DownloadContext<'_>,
 ) -> Result<video::ActiveModel> {
     let _permit = semaphore.acquire().await.context("acquire semaphore failed")?;
+    let _video = DownloadStatsManager::get().track_video();
     let mut status = VideoStatus::from(video_model.download_status);
     let separate_status = status.should_run();
     // 未记录路径时填充，已经填充过路径时使用现有的
@@ -588,7 +590,12 @@ pub async fn fetch_page_poster(
         }
     };
     cx.downloader
-        .fetch(url, &poster_path, &cx.config.concurrent_limit.download)
+        .fetch(
+            url,
+            &poster_path,
+            &cx.config.concurrent_limit.download,
+            DownloadStatsScope::None,
+        )
         .await?;
     if let Some(fanart_path) = fanart_path {
         fs::copy(&poster_path, &fanart_path).await?;
@@ -606,6 +613,7 @@ pub async fn fetch_page_video(
     if !should_run {
         return Ok(ExecutionStatus::Skipped);
     }
+    let _page = DownloadStatsManager::get().track_page();
     let bili_video = Video::new(cx.bili_client, video_model.bvid.as_str(), &cx.config.credential);
     let streams = bili_video
         .get_page_analyzer(page_info)
@@ -618,6 +626,7 @@ pub async fn fetch_page_video(
                     &mix_stream.urls(cx.config.cdn_sorting),
                     page_path,
                     &cx.config.concurrent_limit.download,
+                    DownloadStatsScope::Media,
                 )
                 .await?
         }
@@ -630,6 +639,7 @@ pub async fn fetch_page_video(
                     &video_stream.urls(cx.config.cdn_sorting),
                     page_path,
                     &cx.config.concurrent_limit.download,
+                    DownloadStatsScope::Media,
                 )
                 .await?
         }
@@ -643,6 +653,7 @@ pub async fn fetch_page_video(
                     &audio_stream.urls(cx.config.cdn_sorting),
                     page_path,
                     &cx.config.concurrent_limit.download,
+                    DownloadStatsScope::Media,
                 )
                 .await?
         }
@@ -723,7 +734,12 @@ pub async fn fetch_video_poster(
         return Ok(ExecutionStatus::Skipped);
     }
     cx.downloader
-        .fetch(&video_model.cover, &poster_path, &cx.config.concurrent_limit.download)
+        .fetch(
+            &video_model.cover,
+            &poster_path,
+            &cx.config.concurrent_limit.download,
+            DownloadStatsScope::None,
+        )
         .await?;
     fs::copy(&poster_path, &fanart_path).await?;
     Ok(ExecutionStatus::Succeeded)
@@ -745,6 +761,7 @@ pub async fn fetch_upper_face(
                     upper.face,
                     &base_path.join("folder.jpg"),
                     &cx.config.concurrent_limit.download,
+                    DownloadStatsScope::None,
                 )
                 .await?;
             Ok::<(), anyhow::Error>(())

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
 	CollectionsResponse,
 	Config,
 	DashBoardResponse,
+	DownloadStats,
 	FavoritesResponse,
 	FullSyncVideoSourceRequest,
 	FullSyncVideoSourceResponse,
@@ -304,6 +305,9 @@ class ApiClient {
 	subscribeToTasks(onMessage: (data: TaskStatus) => void) {
 		return wsManager.subscribeToTasks(onMessage);
 	}
+	subscribeToDownloadStats(onMessage: (data: DownloadStats) => void) {
+		return wsManager.subscribeToDownloadStats(onMessage);
+	}
 }
 
 // 创建默认的 API 客户端实例
@@ -354,6 +358,9 @@ const api = {
 
 	subscribeToTasks: (onMessage: (data: TaskStatus) => void) =>
 		apiClient.subscribeToTasks(onMessage),
+
+	subscribeToDownloadStats: (onMessage: (data: DownloadStats) => void) =>
+		apiClient.subscribeToDownloadStats(onMessage),
 
 	setAuthToken: (token: string) => apiClient.setAuthToken(token),
 	getAuthToken: () => apiClient.getAuthToken(),

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -375,6 +375,15 @@ export interface TaskStatus {
 	next_run: Date | null;
 }
 
+export interface DownloadStats {
+	timestamp: number;
+	current_speed_bytes_per_sec: number;
+	task_downloaded_bytes: number;
+	active_videos: number;
+	active_pages: number;
+	active_fragments: number;
+}
+
 export interface UpdateVideoSourceResponse {
 	ruleDisplay: string;
 }

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -1,12 +1,13 @@
 import { toast } from 'svelte-sonner';
 import api from './api';
-import type { SysInfo, TaskStatus } from './types';
+import type { DownloadStats, SysInfo, TaskStatus } from './types';
 
 // 支持的事件类型
 export enum EventType {
 	Logs = 'logs',
 	Tasks = 'tasks',
-	SysInfo = 'sysInfo'
+	SysInfo = 'sysInfo',
+	DownloadStats = 'downloadStats'
 }
 
 // 服务器事件响应格式
@@ -14,6 +15,7 @@ interface ServerEvent {
 	logs?: string;
 	tasks?: TaskStatus;
 	sysInfo?: SysInfo;
+	downloadStats?: DownloadStats;
 }
 
 // 客户端事件请求格式
@@ -26,6 +28,7 @@ interface ClientEvent {
 type LogsCallback = (data: string) => void;
 type TasksCallback = (data: TaskStatus) => void;
 type SysInfoCallback = (data: SysInfo) => void;
+type DownloadStatsCallback = (data: DownloadStats) => void;
 
 export class WebSocketManager {
 	private static instance: WebSocketManager;
@@ -39,6 +42,7 @@ export class WebSocketManager {
 	private logsSubscribers: Set<LogsCallback> = new Set();
 	private tasksSubscribers: Set<TasksCallback> = new Set();
 	private sysInfoSubscribers: Set<SysInfoCallback> = new Set();
+	private downloadStatsSubscribers: Set<DownloadStatsCallback> = new Set();
 
 	private subscribedEvents: Set<EventType> = new Set();
 	private connectionPromise: Promise<void> | null = null;
@@ -111,6 +115,8 @@ export class WebSocketManager {
 				this.notifyTasksSubscribers(data.tasks);
 			} else if (data.sysInfo !== undefined) {
 				this.notifySysInfoSubscribers(data.sysInfo);
+			} else if (data.downloadStats !== undefined) {
+				this.notifyDownloadStatsSubscribers(data.downloadStats);
 			}
 		} catch (error) {
 			console.error('Failed to parse WebSocket message:', error, event.data);
@@ -223,6 +229,21 @@ export class WebSocketManager {
 		};
 	}
 
+	public subscribeToDownloadStats(callback: DownloadStatsCallback): () => void {
+		this.downloadStatsSubscribers.add(callback);
+
+		if (this.downloadStatsSubscribers.size === 1) {
+			this.subscribe(EventType.DownloadStats);
+		}
+
+		return () => {
+			this.downloadStatsSubscribers.delete(callback);
+			if (this.downloadStatsSubscribers.size === 0) {
+				this.unsubscribe(EventType.DownloadStats);
+			}
+		};
+	}
+
 	private notifyLogsSubscribers(data: string): void {
 		this.logsSubscribers.forEach((callback) => {
 			try {
@@ -249,6 +270,16 @@ export class WebSocketManager {
 				callback(data);
 			} catch (error) {
 				console.error('Error in sysInfo subscriber callback:', error);
+			}
+		});
+	}
+
+	private notifyDownloadStatsSubscribers(data: DownloadStats): void {
+		this.downloadStatsSubscribers.forEach((callback) => {
+			try {
+				callback(data);
+			} catch (error) {
+				console.error('Error in download stats subscriber callback:', error);
 			}
 		});
 	}

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -6,13 +6,13 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import * as Chart from '$lib/components/ui/chart/index.js';
 	import MyChartTooltip from '$lib/components/custom/my-chart-tooltip.svelte';
-	import { curveNatural } from 'd3-shape';
+	import { curveMonotoneX, curveNatural } from 'd3-shape';
 	import { BarChart, AreaChart } from 'layerchart';
 	import { setBreadcrumb } from '$lib/stores/breadcrumb';
 	import { toast } from 'svelte-sonner';
 	import CloudDownloadIcon from '@lucide/svelte/icons/cloud-download';
 	import api from '$lib/api';
-	import type { DashBoardResponse, SysInfo, ApiError, TaskStatus } from '$lib/types';
+	import type { DashBoardResponse, DownloadStats, SysInfo, ApiError, TaskStatus } from '$lib/types';
 	import {
 		DatabaseIcon,
 		HeartIcon,
@@ -32,12 +32,15 @@
 	let dashboardData = $state<DashBoardResponse | null>(null);
 	let sysInfo = $state<SysInfo | null>(null);
 	let taskStatus = $state<TaskStatus | null>(null);
+	let downloadStats = $state<DownloadStats | null>(null);
 	let loading = $state(false);
 	let triggering = $state(false);
 	let memoryHistory = $state<Array<{ time: number; used: number; process: number }>>([]);
 	let cpuHistory = $state<Array<{ time: number; used: number; process: number }>>([]);
+	let downloadSpeedHistory = $state<Array<{ time: number; speed: number }>>([]);
 	let unsubscribeSysInfo: (() => void) | null = null;
 	let unsubscribeTasks: (() => void) | null = null;
+	let unsubscribeDownloadStats: (() => void) | null = null;
 
 	function formatBytes(bytes: number): string {
 		if (bytes === 0) return '0 B';
@@ -51,12 +54,34 @@
 		return `${cpu.toFixed(1)}%`;
 	}
 
+	function formatSpeed(bytesPerSecond: number): string {
+		return `${formatBytes(bytesPerSecond)}/s`;
+	}
+
+	function formatSpeedTick(bytesPerSecond: number, domainMax: number): string {
+		if (domainMax >= 1024 * 1024) {
+			return `${(bytesPerSecond / (1024 * 1024)).toFixed(1)} MB/s`;
+		}
+		if (domainMax >= 1024) {
+			return `${Math.round(bytesPerSecond / 1024)} KB/s`;
+		}
+		return `${Math.round(bytesPerSecond)} B/s`;
+	}
+
 	function formatTimestamp(timestamp: number): string {
 		return new Date(timestamp).toLocaleString('en-US', {
 			hour: '2-digit',
 			minute: '2-digit',
 			second: '2-digit',
 			hour12: true
+		});
+	}
+
+	function formatAxisTimestamp(timestamp: number): string {
+		return new Date(timestamp).toLocaleTimeString('zh-CN', {
+			hour: '2-digit',
+			minute: '2-digit',
+			second: '2-digit'
 		});
 	}
 
@@ -121,6 +146,13 @@
 		}
 	} satisfies Chart.ChartConfig;
 
+	const downloadSpeedChartConfig = {
+		speed: {
+			label: '下载速度',
+			color: 'var(--primary)'
+		}
+	} satisfies Chart.ChartConfig;
+
 	function pushSysInfo(data: SysInfo) {
 		memoryHistory = [
 			...memoryHistory.slice(-14),
@@ -140,8 +172,27 @@
 		];
 	}
 
+	function pushDownloadStats(data: DownloadStats) {
+		downloadSpeedHistory = [
+			...downloadSpeedHistory.slice(-14),
+			{
+				time: data.timestamp,
+				speed: data.current_speed_bytes_per_sec
+			}
+		];
+	}
+
 	const diskUsagePercent = $derived(
 		sysInfo ? ((sysInfo.total_disk - sysInfo.available_disk) / sysInfo.total_disk) * 100 : 0
+	);
+	const downloadSpeedDomainMax = $derived(
+		Math.max(
+			1024,
+			Math.ceil(
+				Math.max(...downloadSpeedHistory.map((point) => point.speed), downloadStats?.current_speed_bytes_per_sec ?? 0) *
+					1.1
+			)
+		)
 	);
 
 	onMount(() => {
@@ -154,6 +205,10 @@
 		unsubscribeTasks = api.subscribeToTasks((data: TaskStatus) => {
 			taskStatus = data;
 		});
+		unsubscribeDownloadStats = api.subscribeToDownloadStats((data: DownloadStats) => {
+			downloadStats = data;
+			pushDownloadStats(data);
+		});
 		loadDashboard();
 		return () => {
 			if (unsubscribeSysInfo) {
@@ -163,6 +218,10 @@
 			if (unsubscribeTasks) {
 				unsubscribeTasks();
 				unsubscribeTasks = null;
+			}
+			if (unsubscribeDownloadStats) {
+				unsubscribeDownloadStats();
+				unsubscribeDownloadStats = null;
 			}
 		};
 	});
@@ -396,6 +455,109 @@
 		</div>
 
 		<!-- 第三行：系统监控 -->
+		<div class="grid gap-4 md:grid-cols-3">
+			<Card class="md:col-span-1">
+				<CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
+					<CardTitle class="text-sm font-medium">运行概览</CardTitle>
+					<CloudDownloadIcon class="text-muted-foreground h-4 w-4" />
+				</CardHeader>
+				<CardContent>
+					{#if downloadStats}
+						<div class="space-y-4">
+							<div>
+								<div class="text-muted-foreground text-xs">当前下载速度</div>
+								<div class="mt-1 text-2xl font-bold">
+									{formatSpeed(downloadStats.current_speed_bytes_per_sec)}
+								</div>
+							</div>
+							<div class="grid grid-cols-3 gap-3 text-center">
+								<div class="rounded-md border p-3">
+									<div class="text-lg font-semibold">{downloadStats.active_videos}</div>
+									<div class="text-muted-foreground mt-1 text-xs">视频</div>
+								</div>
+								<div class="rounded-md border p-3">
+									<div class="text-lg font-semibold">{downloadStats.active_pages}</div>
+									<div class="text-muted-foreground mt-1 text-xs">分页</div>
+								</div>
+								<div class="rounded-md border p-3">
+									<div class="text-lg font-semibold">{downloadStats.active_fragments}</div>
+									<div class="text-muted-foreground mt-1 text-xs">分片</div>
+								</div>
+							</div>
+							<div class="flex items-center justify-between border-t pt-3 text-sm">
+								<span class="text-muted-foreground">本轮累计下载</span>
+								<span class="font-medium">{formatBytes(downloadStats.task_downloaded_bytes)}</span>
+							</div>
+						</div>
+					{:else}
+						<div class="text-muted-foreground text-sm">等待数据...</div>
+					{/if}
+				</CardContent>
+			</Card>
+			<Card class="overflow-hidden md:col-span-2">
+				<CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
+					<CardTitle class="text-sm font-medium">下载速度</CardTitle>
+					<DownloadIcon class="text-muted-foreground h-4 w-4" />
+				</CardHeader>
+				<CardContent>
+					{#if downloadSpeedHistory.length > 0}
+						<Chart.Container config={downloadSpeedChartConfig} class="h-[150px] w-full">
+							<AreaChart
+								data={downloadSpeedHistory}
+								x="time"
+								axis={true}
+								yDomain={[0, downloadSpeedDomainMax]}
+								padding={{
+									left: 72,
+									right: 12,
+									top: 8,
+									bottom: 28
+								}}
+								series={[
+									{
+										key: 'speed',
+										label: downloadSpeedChartConfig.speed.label,
+										color: downloadSpeedChartConfig.speed.color
+									}
+								]}
+								props={{
+									area: {
+										curve: curveMonotoneX,
+										line: { class: 'stroke-1' },
+										'fill-opacity': 0.4
+									},
+									xAxis: {
+										grid: false,
+										ticks: 4,
+										format: (value: number) => formatAxisTimestamp(value)
+									},
+									yAxis: {
+										grid: true,
+										ticks: 4,
+										format: (value: number) => formatSpeedTick(value, downloadSpeedDomainMax)
+									}
+								}}
+							>
+								{#snippet tooltip()}
+									<MyChartTooltip
+										labelFormatter={(timestamp: number) => {
+											return formatTimestamp(timestamp);
+										}}
+										valueFormatter={(v: number) => formatSpeed(v)}
+										indicator="line"
+									/>
+								{/snippet}
+							</AreaChart>
+						</Chart.Container>
+					{:else}
+						<div class="text-muted-foreground flex h-[150px] items-center justify-center text-sm">
+							等待数据...
+						</div>
+					{/if}
+				</CardContent>
+			</Card>
+		</div>
+
 		<div class="grid gap-4 md:grid-cols-2">
 			<!-- 内存使用情况 -->
 			<Card class="overflow-hidden">


### PR DESCRIPTION
## Summary
- add runtime download stats for bili-sync download traffic on the dashboard
- stream download stats over websocket and show runtime overview plus download speed chart
- tighten the runtime metrics scope so media download traffic is counted while poster/avatar fetches are excluded

## Validation
- cargo test
- cargo clippy -- -D warnings
- cargo +nightly fmt --check
- cd web && bun run check
- cd web && bun run build
