### PR TITLE
feat: 支持自动更新弹幕

### DIFF
--- a/crates/bili_sync/src/config/current.rs
+++ b/crates/bili_sync/src/config/current.rs
@@ -14,7 +14,7 @@ use crate::config::default::{
     default_auth_token, default_bind_address, default_collection_path, default_favorite_path, default_submission_path,
     default_time_format,
 };
-use crate::config::item::{ConcurrentLimit, NFOTimeType, SkipOption, Trigger};
+use crate::config::item::{ConcurrentLimit, DanmakuUpdatePolicy, NFOTimeType, SkipOption, Trigger};
 use crate::notifier::Notifier;
 use crate::utils::model::{load_db_config, save_db_config};
 
@@ -32,6 +32,8 @@ pub struct Config {
     pub credential: Credential,
     pub filter_option: FilterOption,
     pub danmaku_option: DanmakuOption,
+    #[serde(default)]
+    pub danmaku_update_policy: DanmakuUpdatePolicy,
     #[serde(default)]
     pub skip_option: SkipOption,
     pub video_name: String,
@@ -107,6 +109,9 @@ impl Config {
                 }
             }
         };
+        if let Err(error) = self.danmaku_update_policy.validate() {
+            errors.push(error);
+        }
         if !errors.is_empty() {
             bail!(errors.into_iter().map(|e| format!("- {}", e)).join("\n"));
         }
@@ -122,6 +127,7 @@ impl Default for Config {
             credential: Credential::default(),
             filter_option: FilterOption::default(),
             danmaku_option: DanmakuOption::default(),
+            danmaku_update_policy: DanmakuUpdatePolicy::default(),
             skip_option: SkipOption::default(),
             video_name: "{{title}}".to_owned(),
             page_name: "{{bvid}}".to_owned(),

--- a/crates/bili_sync/src/config/item.rs
+++ b/crates/bili_sync/src/config/item.rs
@@ -82,6 +82,57 @@ impl Default for Trigger {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct DanmakuUpdatePolicy {
+    pub enabled: bool,
+    pub milestones: Vec<DanmakuUpdateMilestone>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum DanmakuUpdateMilestone {
+    Once { at_days: u32 },
+    Periodic { until_days: u32, interval_hours: u32 },
+}
+
+impl DanmakuUpdateMilestone {
+    pub fn end_days(self) -> i64 {
+        i64::from(match self {
+            Self::Once { at_days } => at_days,
+            Self::Periodic { until_days, .. } => until_days,
+        })
+    }
+
+    pub fn start_hours(self) -> i64 {
+        match self {
+            DanmakuUpdateMilestone::Once { at_days } => at_days as i64 * 24,
+            DanmakuUpdateMilestone::Periodic {
+                until_days,
+                interval_hours,
+            } => i64::min(until_days as i64 * 24, interval_hours as i64),
+        }
+    }
+}
+
+impl DanmakuUpdatePolicy {
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if !self.enabled {
+            return Ok(());
+        }
+        let mut previous_end_days = 0;
+        for milestone in &self.milestones {
+            if milestone.end_days() <= previous_end_days {
+                return Err("弹幕更新的里程碑天数必须大于 0 且严格递增");
+            }
+            if matches!(milestone, DanmakuUpdateMilestone::Periodic { interval_hours: 0, .. }) {
+                return Err("弹幕更新的刷新间隔必须大于 0");
+            }
+            previous_end_days = milestone.end_days();
+        }
+        Ok(())
+    }
+}
+
 pub trait PathSafeTemplate {
     fn path_safe_register(&mut self, name: &'static str, template: impl Into<String>) -> Result<()>;
     fn path_safe_render(&self, name: &'static str, data: &serde_json::Value) -> Result<String>;

--- a/crates/bili_sync/src/config/mod.rs
+++ b/crates/bili_sync/src/config/mod.rs
@@ -10,6 +10,8 @@ pub use crate::config::args::{ARGS, version};
 pub use crate::config::current::{CONFIG_DIR, Config};
 pub(crate) use crate::config::default::default_bind_address;
 pub use crate::config::handlebar::TEMPLATE;
-pub use crate::config::item::{ConcurrentDownloadLimit, NFOTimeType, PathSafeTemplate, RateLimit, Trigger};
+pub use crate::config::item::{
+    ConcurrentDownloadLimit, DanmakuUpdateMilestone, NFOTimeType, PathSafeTemplate, RateLimit, Trigger,
+};
 pub use crate::config::versioned_cache::VersionedCache;
 pub use crate::config::versioned_config::VersionedConfig;

--- a/crates/bili_sync/src/notifier/info.rs
+++ b/crates/bili_sync/src/notifier/info.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use bili_sync_entity::video;
 
 use crate::utils::status::{STATUS_OK, VideoStatus};
@@ -24,12 +26,12 @@ impl DownloadNotifyInfo {
         }
     }
 
-    pub fn record(&mut self, models: &[video::ActiveModel]) {
+    pub fn record(&mut self, models: &[video::ActiveModel], excluded_video_ids: &HashSet<i32>) {
         let success_models = models
             .iter()
             .filter(|m| {
                 let sub_task_status: [u32; 5] = VideoStatus::from(*m.download_status.as_ref()).into();
-                sub_task_status.into_iter().all(|s| s == STATUS_OK)
+                !excluded_video_ids.contains(m.id.as_ref()) && sub_task_status.into_iter().all(|s| s == STATUS_OK)
             })
             .collect::<Vec<_>>();
         match self {

--- a/crates/bili_sync/src/utils/danmaku_schedule.rs
+++ b/crates/bili_sync/src/utils/danmaku_schedule.rs
@@ -1,0 +1,159 @@
+use chrono::{DateTime, Duration, Utc};
+
+use crate::config::DanmakuUpdateMilestone;
+
+pub fn should_sync_danmaku(
+    milestones: &[DanmakuUpdateMilestone],
+    pubtime: DateTime<Utc>,
+    last_synced_at: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> bool {
+    let last_synced_at = last_synced_at.unwrap_or(pubtime);
+    let mut stage_start = pubtime;
+    for milestone in milestones {
+        match milestone {
+            DanmakuUpdateMilestone::Once { at_days } => {
+                let sync_at = pubtime + Duration::days((*at_days).into());
+                if last_synced_at < sync_at && now >= sync_at {
+                    return true;
+                }
+                stage_start = sync_at;
+            }
+            DanmakuUpdateMilestone::Periodic {
+                until_days,
+                interval_hours,
+            } => {
+                let stage_end = pubtime + Duration::days((*until_days).into());
+                if now >= stage_end {
+                    if last_synced_at < stage_end {
+                        return true;
+                    }
+                } else if now > stage_start {
+                    let interval = Duration::hours((*interval_hours).into());
+                    return last_synced_at < stage_start || now.signed_duration_since(last_synced_at) >= interval;
+                } else {
+                    return false;
+                }
+                stage_start = stage_end;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+
+    use super::*;
+
+    fn periodic_policy() -> Vec<DanmakuUpdateMilestone> {
+        vec![periodic(3, 6), periodic(30, 3 * 24), periodic(180, 30 * 24)]
+    }
+
+    fn once(at_days: u32) -> DanmakuUpdateMilestone {
+        DanmakuUpdateMilestone::Once { at_days }
+    }
+
+    fn periodic(until_days: u32, interval_hours: u32) -> DanmakuUpdateMilestone {
+        DanmakuUpdateMilestone::Periodic {
+            until_days,
+            interval_hours,
+        }
+    }
+
+    #[test]
+    fn t(days: i64, hours: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(0, 0).unwrap() + Duration::days(days) + Duration::hours(hours)
+    }
+
+    #[test]
+    fn empty_milestones_never_syncs() {
+        let policy = vec![];
+        assert!(!should_sync_danmaku(&policy, t(0, 0), None, t(1, 0)));
+    }
+
+    #[test]
+    fn once_items_sync_only_after_their_milestones() {
+        let policy = vec![once(3), once(10), once(30)];
+        assert!(!should_sync_danmaku(&policy, t(0, 0), Some(t(0, 0)), t(2, 23)));
+        assert!(should_sync_danmaku(&policy, t(0, 0), Some(t(0, 0)), t(3, 0)));
+        assert!(!should_sync_danmaku(&policy, t(0, 0), Some(t(5, 0)), t(9, 23)));
+        assert!(should_sync_danmaku(&policy, t(0, 0), Some(t(5, 0)), t(10, 0)));
+    }
+
+    #[test]
+    fn missing_last_synced_at_uses_pubtime_as_the_baseline() {
+        let once_policy = vec![once(3)];
+        assert!(!should_sync_danmaku(&once_policy, t(0, 0), None, t(2, 23)));
+        assert!(should_sync_danmaku(&once_policy, t(0, 0), None, t(3, 0)));
+
+        let periodic_policy = vec![periodic(3, 6)];
+        assert!(!should_sync_danmaku(&periodic_policy, t(0, 0), None, t(0, 5)));
+        assert!(should_sync_danmaku(&periodic_policy, t(0, 0), None, t(0, 6)));
+    }
+
+    #[test]
+    fn periodic_items_use_the_last_successful_sync() {
+        let policy = periodic_policy();
+        assert!(!should_sync_danmaku(&policy, t(0, 0), Some(t(1, 0)), t(1, 5)));
+        assert!(should_sync_danmaku(&policy, t(0, 0), Some(t(1, 0)), t(1, 6)));
+    }
+
+    #[test]
+    fn entering_a_new_periodic_stage_syncs_immediately() {
+        assert!(should_sync_danmaku(
+            &periodic_policy(),
+            t(0, 0),
+            Some(t(2, 23)),
+            t(3, 0)
+        ));
+    }
+
+    #[test]
+    fn mixed_items_share_one_timeline() {
+        let policy = vec![periodic(3, 6), once(10), periodic(30, 3 * 24)];
+        assert!(!should_sync_danmaku(&policy, t(0, 0), Some(t(4, 0)), t(9, 23)));
+        assert!(should_sync_danmaku(&policy, t(0, 0), Some(t(4, 0)), t(10, 0)));
+        assert!(!should_sync_danmaku(&policy, t(0, 0), Some(t(10, 0)), t(12, 23)));
+        assert!(should_sync_danmaku(&policy, t(0, 0), Some(t(10, 0)), t(13, 0)));
+    }
+
+    #[test]
+    fn passing_multiple_items_requires_only_one_sync() {
+        let policy = vec![once(3), once(10), once(30)];
+        assert!(should_sync_danmaku(&policy, t(0, 0), Some(t(1, 0)), t(31, 0)));
+        assert!(!should_sync_danmaku(&policy, t(0, 0), Some(t(31, 0)), t(31, 0)));
+    }
+
+    #[test]
+    fn final_periodic_boundary_syncs_once_then_freezes() {
+        assert!(should_sync_danmaku(
+            &periodic_policy(),
+            t(0, 0),
+            Some(t(170, 0)),
+            t(200, 0)
+        ));
+        assert!(!should_sync_danmaku(
+            &periodic_policy(),
+            t(0, 0),
+            Some(t(180, 0)),
+            t(200, 0)
+        ));
+    }
+
+    #[test]
+    fn interval_changes_take_effect_immediately() {
+        let mut policy = periodic_policy();
+        policy[1] = periodic(30, 10 * 24);
+        assert!(!should_sync_danmaku(&policy, t(0, 0), Some(t(10, 0)), t(15, 0)));
+        policy[1] = periodic(30, 3 * 24);
+        assert!(should_sync_danmaku(&policy, t(0, 0), Some(t(10, 0)), t(15, 0)));
+    }
+
+    #[test]
+    fn inserted_once_item_takes_effect_immediately() {
+        let policy = vec![once(3), once(7), once(10)];
+        assert!(should_sync_danmaku(&policy, t(0, 0), Some(t(5, 0)), t(8, 0)));
+    }
+}

--- a/crates/bili_sync/src/utils/danmaku_schedule.rs
+++ b/crates/bili_sync/src/utils/danmaku_schedule.rs
@@ -62,7 +62,6 @@ mod tests {
         }
     }
 
-    #[test]
     fn t(days: i64, hours: i64) -> DateTime<Utc> {
         Utc.timestamp_opt(0, 0).unwrap() + Duration::days(days) + Duration::hours(hours)
     }

--- a/crates/bili_sync/src/utils/mod.rs
+++ b/crates/bili_sync/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod convert;
+pub mod danmaku_schedule;
 pub mod download_context;
 pub mod filenamify;
 pub mod format_arg;

--- a/crates/bili_sync/src/utils/model.rs
+++ b/crates/bili_sync/src/utils/model.rs
@@ -196,11 +196,15 @@ pub async fn update_videos_model(videos: Vec<video::ActiveModel>, connection: &D
     Ok(())
 }
 
-/// 更新视频页 model 的下载状态
+/// 更新视频页 model 的下载状态、路径和弹幕同步时间
 pub async fn update_pages_model(pages: Vec<page::ActiveModel>, connection: &DatabaseConnection) -> Result<()> {
     let query = page::Entity::insert_many(pages).on_conflict(
         OnConflict::column(page::Column::Id)
-            .update_columns([page::Column::DownloadStatus, page::Column::Path])
+            .update_columns([
+                page::Column::DownloadStatus,
+                page::Column::Path,
+                page::Column::DanmakuLastSyncedAt,
+            ])
             .to_owned(),
     );
     query.exec(connection).await?;

--- a/crates/bili_sync/src/utils/status.rs
+++ b/crates/bili_sync/src/utils/status.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use bili_sync_entity::{page, video};
 use bili_sync_migration::{ExprTrait, IntoCondition};
-use sea_orm::sea_query::Expr;
+use sea_orm::sea_query::{Expr, SimpleExpr};
 use sea_orm::{ColumnTrait, Condition};
 
 use crate::error::ExecutionStatus;
@@ -213,11 +213,27 @@ impl<const N: usize, C: ColumnTrait> StatusQueryBuilder<N, C> {
         Self { column }
     }
 
+    fn subtask_status(&self, offset: usize) -> SimpleExpr {
+        assert!(offset < N, "status offset should be less than status length");
+        Expr::col(self.column.as_column_ref())
+            .right_shift((offset * 3) as i32)
+            .bit_and(0b111)
+    }
+
+    pub fn subtask_succeeded(&self, offset: usize) -> SimpleExpr {
+        self.subtask_status(offset).eq(STATUS_OK)
+    }
+
+    pub fn reset_subtask(&self, offset: usize) -> SimpleExpr {
+        assert!(offset < N, "status offset should be less than status length");
+        Expr::col(self.column.as_column_ref()).bit_and(!(STATUS_COMPLETED | (0b111 << (offset * 3))))
+    }
+
     /// 完成状态：所有子任务的状态都是成功
     pub fn succeeded(&self) -> Condition {
         let mut condition = Condition::all();
-        for offset in 0..N as i32 {
-            condition = condition.add(Expr::col(self.column).right_shift(offset * 3).bit_and(7).eq(7))
+        for offset in 0..N {
+            condition = condition.add(self.subtask_succeeded(offset))
         }
         condition
     }
@@ -225,13 +241,8 @@ impl<const N: usize, C: ColumnTrait> StatusQueryBuilder<N, C> {
     /// 失败状态：存在任何失败的子任务
     pub fn failed(&self) -> Condition {
         let mut condition = Condition::any();
-        for offset in 0..N as i32 {
-            condition = condition.add(
-                Expr::col(self.column)
-                    .right_shift(offset * 3)
-                    .bit_and(7)
-                    .is_not_in([0, 7]),
-            )
+        for offset in 0..N {
+            condition = condition.add(self.subtask_status(offset).is_not_in([STATUS_NOT_STARTED, STATUS_OK]))
         }
         condition
     }
@@ -239,8 +250,8 @@ impl<const N: usize, C: ColumnTrait> StatusQueryBuilder<N, C> {
     /// 等待状态：所有子任务的状态都不是失败，且其中存在未开始
     pub fn waiting(&self) -> Condition {
         let mut condition = Condition::any();
-        for offset in 0..N as i32 {
-            condition = condition.add(Expr::col(self.column).right_shift(offset * 3).bit_and(7).eq(0))
+        for offset in 0..N {
+            condition = condition.add(self.subtask_status(offset).eq(STATUS_NOT_STARTED))
         }
         condition.and(self.failed().not()).into_condition()
     }
@@ -249,8 +260,21 @@ impl<const N: usize, C: ColumnTrait> StatusQueryBuilder<N, C> {
 #[cfg(test)]
 mod tests {
     use anyhow::anyhow;
+    use sea_orm::{DbBackend, EntityTrait, QueryFilter, QueryTrait};
 
     use super::*;
+
+    #[test]
+    fn test_subtask_succeeded_query() {
+        let query = page::Entity::find()
+            .filter(PageStatus::query_builder().subtask_succeeded(3))
+            .build(DbBackend::Sqlite)
+            .to_string();
+        assert!(
+            query.contains("((\"page\".\"download_status\" >> 9) & 7) = 7"),
+            "{query}"
+        );
+    }
 
     #[test]
     fn test_status_update() {

--- a/crates/bili_sync/src/workflow.rs
+++ b/crates/bili_sync/src/workflow.rs
@@ -59,13 +59,20 @@ pub async fn process_video_source(
     // 单独请求视频详情接口，获取视频的详情信息与所有的分页，写入数据库
     fetch_video_details(bili_client, &video_source, connection, config).await?;
     // 根据弹幕更新规则清空弹幕任务的标记位，允许后续任务覆盖
-    prepare_danmaku_updates(&video_source, connection, config).await?;
+    let danmaku_update_video_ids = prepare_danmaku_updates(&video_source, connection, config).await?;
     if ARGS.scan_only {
         warn!("已开启仅扫描模式，跳过视频下载..");
     } else {
         // 从数据库中查找所有未下载的视频与分页，下载并处理
-        let download_notify_info =
-            download_unprocessed_videos(bili_client, &video_source, connection, template, config).await?;
+        let download_notify_info = download_unprocessed_videos(
+            bili_client,
+            &video_source,
+            connection,
+            template,
+            config,
+            &danmaku_update_video_ids,
+        )
+        .await?;
         if download_notify_info.should_notify() {
             notify(config, bili_client, download_notify_info);
         }
@@ -205,6 +212,7 @@ pub async fn download_unprocessed_videos(
     connection: &DatabaseConnection,
     template: &handlebars::Handlebars<'_>,
     config: &Config,
+    danmaku_update_video_ids: &HashSet<i32>,
 ) -> Result<DownloadNotifyInfo> {
     video_source.log_download_video_start();
     let downloader = Downloader::new(bili_client.client.clone());
@@ -267,7 +275,7 @@ pub async fn download_unprocessed_videos(
         .chunks(10);
     let mut download_notify_info = DownloadNotifyInfo::new(video_source.display_name().into());
     while let Some(models) = stream.next().await {
-        download_notify_info.record(&models);
+        download_notify_info.record(&models, danmaku_update_video_ids);
         update_videos_model(models, connection).await?;
     }
     if let Some(e) = risk_control_related_error {
@@ -281,12 +289,12 @@ async fn prepare_danmaku_updates(
     video_source: &VideoSourceEnum,
     connection: &DatabaseConnection,
     config: &Config,
-) -> Result<()> {
+) -> Result<HashSet<i32>> {
     if !config.danmaku_update_policy.enabled
         || config.danmaku_update_policy.milestones.is_empty()
         || config.skip_option.no_danmaku
     {
-        return Ok(());
+        return Ok(HashSet::new());
     }
     let now = chrono::Utc::now();
     // safety: milestones are checked to be non-empty
@@ -341,7 +349,7 @@ async fn prepare_danmaku_updates(
         }
     }
     if due_page_ids.is_empty() {
-        return Ok(());
+        return Ok(HashSet::new());
     }
     let (reset_video_count, reset_page_count) = (due_video_ids.len(), due_page_ids.len());
     let txn = connection.begin().await?;
@@ -358,7 +366,7 @@ async fn prepare_danmaku_updates(
             video::Column::DownloadStatus,
             VideoStatus::query_builder().reset_subtask(VIDEO_PAGE_STATUS_OFFSET),
         )
-        .filter(video::Column::Id.is_in(due_video_ids))
+        .filter(video::Column::Id.is_in(due_video_ids.iter().copied()))
         .exec(&txn)
         .await?;
     txn.commit().await?;
@@ -368,7 +376,7 @@ async fn prepare_danmaku_updates(
             reset_video_count, reset_page_count
         );
     }
-    Ok(())
+    Ok(due_video_ids.into_iter().collect())
 }
 
 pub async fn download_video_pages(

--- a/crates/bili_sync/src/workflow.rs
+++ b/crates/bili_sync/src/workflow.rs
@@ -8,8 +8,9 @@ use bili_sync_entity::*;
 use futures::stream::{self, FuturesUnordered};
 use futures::{Stream, StreamExt, TryStreamExt};
 use sea_orm::ActiveValue::Set;
-use sea_orm::TransactionTrait;
 use sea_orm::entity::prelude::*;
+use sea_orm::sea_query::{Alias, ExprTrait, Func};
+use sea_orm::{IntoSimpleExpr, TransactionTrait};
 use tokio::fs;
 
 use crate::adapter::{VideoSource, VideoSourceEnum};
@@ -18,6 +19,7 @@ use crate::config::{ARGS, Config, PathSafeTemplate};
 use crate::downloader::Downloader;
 use crate::error::ExecutionStatus;
 use crate::notifier::DownloadNotifyInfo;
+use crate::utils::danmaku_schedule::should_sync_danmaku;
 use crate::utils::download_context::DownloadContext;
 use crate::utils::format_arg::{page_format_args, video_format_args};
 use crate::utils::model::{
@@ -28,6 +30,9 @@ use crate::utils::nfo::{NFO, ToNFO};
 use crate::utils::notify::notify;
 use crate::utils::rule::FieldEvaluatable;
 use crate::utils::status::{PageStatus, STATUS_OK, VideoStatus};
+
+const DANMAKU_STATUS_OFFSET: usize = 3;
+const VIDEO_PAGE_STATUS_OFFSET: usize = 4;
 
 #[allow(clippy::large_enum_variant)]
 enum VideoDetailUpdate {
@@ -53,6 +58,8 @@ pub async fn process_video_source(
     refresh_video_source(&video_source, video_streams, connection).await?;
     // 单独请求视频详情接口，获取视频的详情信息与所有的分页，写入数据库
     fetch_video_details(bili_client, &video_source, connection, config).await?;
+    // 根据弹幕更新规则清空弹幕任务的标记位，允许后续任务覆盖
+    prepare_danmaku_updates(&video_source, connection, config).await?;
     if ARGS.scan_only {
         warn!("已开启仅扫描模式，跳过视频下载..");
     } else {
@@ -268,6 +275,100 @@ pub async fn download_unprocessed_videos(
     }
     video_source.log_download_video_end();
     Ok(download_notify_info)
+}
+
+async fn prepare_danmaku_updates(
+    video_source: &VideoSourceEnum,
+    connection: &DatabaseConnection,
+    config: &Config,
+) -> Result<()> {
+    if !config.danmaku_update_policy.enabled
+        || config.danmaku_update_policy.milestones.is_empty()
+        || config.skip_option.no_danmaku
+    {
+        return Ok(());
+    }
+    let now = chrono::Utc::now();
+    // safety: milestones are checked to be non-empty
+    let (first_milestone, last_milestone) = (
+        config.danmaku_update_policy.milestones.first().unwrap(),
+        config.danmaku_update_policy.milestones.last().unwrap(),
+    );
+    let (start_hours, end_days) = (first_milestone.start_hours(), last_milestone.end_days());
+    let (milestone_newest_pubtime, milestone_oldest_pubtime) = (
+        now - chrono::Duration::hours(start_hours),
+        now - chrono::Duration::days(end_days),
+    );
+    let within_schedule = video::Column::Pubtime.gte(milestone_oldest_pubtime.naive_utc());
+    let final_sync_pending = page::Column::DanmakuLastSyncedAt
+        .is_null()
+        .or(page::Column::DanmakuLastSyncedAt
+            .into_simple_expr()
+            .lt(Func::cust(Alias::new("datetime"))
+                .arg(video::Column::Pubtime.into_simple_expr())
+                .arg(format!("+{} days", end_days))));
+    let candidates = video::Entity::find()
+        .filter(
+            video::Column::Valid
+                .eq(true)
+                .and(video::Column::Category.eq(2))
+                .and(video::Column::SinglePage.is_not_null())
+                .and(video::Column::ShouldDownload.eq(true))
+                .and(video::Column::Pubtime.lte(milestone_newest_pubtime.naive_utc()))
+                .and(video_source.filter_expr()),
+        )
+        .find_with_related(page::Entity)
+        .filter(PageStatus::query_builder().subtask_succeeded(DANMAKU_STATUS_OFFSET))
+        .filter(within_schedule.or(final_sync_pending))
+        .all(connection)
+        .await?;
+    let mut due_page_ids = Vec::new();
+    let mut due_video_ids = Vec::new();
+    for (video_model, pages) in candidates {
+        let page_count_before = due_page_ids.len();
+        for page_model in pages {
+            if should_sync_danmaku(
+                &config.danmaku_update_policy.milestones,
+                video_model.pubtime.and_utc(),
+                page_model.danmaku_last_synced_at.map(|time| time.and_utc()),
+                now,
+            ) {
+                due_page_ids.push(page_model.id);
+            }
+        }
+        if due_page_ids.len() > page_count_before {
+            due_video_ids.push(video_model.id);
+        }
+    }
+    if due_page_ids.is_empty() {
+        return Ok(());
+    }
+    let (reset_video_count, reset_page_count) = (due_video_ids.len(), due_page_ids.len());
+    let txn = connection.begin().await?;
+    page::Entity::update_many()
+        .col_expr(
+            page::Column::DownloadStatus,
+            PageStatus::query_builder().reset_subtask(DANMAKU_STATUS_OFFSET),
+        )
+        .filter(page::Column::Id.is_in(due_page_ids))
+        .exec(&txn)
+        .await?;
+    video::Entity::update_many()
+        .col_expr(
+            video::Column::DownloadStatus,
+            VideoStatus::query_builder().reset_subtask(VIDEO_PAGE_STATUS_OFFSET),
+        )
+        .filter(video::Column::Id.is_in(due_video_ids))
+        .exec(&txn)
+        .await?;
+    txn.commit().await?;
+    if reset_video_count > 0 && reset_page_count > 0 {
+        info!(
+            "已将 {} 个视频中的 {} 分页加入本次弹幕更新",
+            reset_video_count, reset_page_count
+        );
+    }
+    Ok(())
 }
 
 pub async fn download_video_pages(
@@ -561,6 +662,7 @@ pub async fn download_page(
     );
     let results = [res_1.into(), res_2.into(), res_3.into(), res_4.into(), res_5.into()];
     status.update_status(&results);
+    let danmaku_succeeded = matches!(&results[DANMAKU_STATUS_OFFSET], ExecutionStatus::Succeeded);
     results
         .iter()
         .zip(["封面", "视频", "详情", "弹幕", "字幕"])
@@ -596,6 +698,9 @@ pub async fn download_page(
     let mut page_active_model: page::ActiveModel = page_model.into();
     page_active_model.download_status = Set(status.into());
     page_active_model.path = Set(Some(video_path.to_string_lossy().to_string()));
+    if danmaku_succeeded {
+        page_active_model.danmaku_last_synced_at = Set(Some(chrono::Utc::now().naive_utc()));
+    }
     Ok(page_active_model)
 }
 

--- a/crates/bili_sync_entity/src/entities/page.rs
+++ b/crates/bili_sync_entity/src/entities/page.rs
@@ -17,6 +17,7 @@ pub struct Model {
     pub path: Option<String>,
     pub image: Option<String>,
     pub download_status: u32,
+    pub danmaku_last_synced_at: Option<DateTime>,
     pub created_at: String,
 }
 

--- a/crates/bili_sync_migration/src/lib.rs
+++ b/crates/bili_sync_migration/src/lib.rs
@@ -13,6 +13,7 @@ mod m20251009_123713_add_use_dynamic_api;
 mod m20260324_055217_add_staff;
 mod m20260712_123205_add_filter_option;
 mod m20260821_025000_mark_empty_tags_for_refetch;
+mod m20260823_000001_add_danmaku_last_synced_at;
 
 pub struct Migrator;
 
@@ -33,6 +34,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260324_055217_add_staff::Migration),
             Box::new(m20260712_123205_add_filter_option::Migration),
             Box::new(m20260821_025000_mark_empty_tags_for_refetch::Migration),
+            Box::new(m20260823_000001_add_danmaku_last_synced_at::Migration),
         ]
     }
 }

--- a/crates/bili_sync_migration/src/m20260823_000001_add_danmaku_last_synced_at.rs
+++ b/crates/bili_sync_migration/src/m20260823_000001_add_danmaku_last_synced_at.rs
@@ -1,0 +1,43 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::schema::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Page::Table)
+                    .add_column(timestamp_null(Page::DanmakuLastSyncedAt))
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "UPDATE page SET danmaku_last_synced_at = CURRENT_TIMESTAMP WHERE ((download_status >> 9) & 7) = 7",
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Page::Table)
+                    .drop_column(Page::DanmakuLastSyncedAt)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Page {
+    Table,
+    DanmakuLastSyncedAt,
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -284,6 +284,15 @@ export interface DanmakuOption {
 	time_offset: number;
 }
 
+export interface DanmakuUpdatePolicy {
+	enabled: boolean;
+	milestones: DanmakuUpdateMilestone[];
+}
+
+export type DanmakuUpdateMilestone =
+	| { type: 'once'; at_days: number }
+	| { type: 'periodic'; until_days: number; interval_hours: number };
+
 export interface SkipOption {
 	no_poster: boolean;
 	no_video_nfo: boolean;
@@ -334,6 +343,7 @@ export interface Config {
 	credential: Credential;
 	filter_option: FilterOption;
 	danmaku_option: DanmakuOption;
+	danmaku_update_policy: DanmakuUpdatePolicy;
 	skip_option: SkipOption;
 	video_name: string;
 	page_name: string;

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -713,8 +713,7 @@
 									{/if}
 									<Button
 										variant="outline"
-										disabled={!formData.danmaku_update_policy.enabled ||
-											formData.danmaku_update_policy.milestones.length === 1}
+										disabled={!formData.danmaku_update_policy.enabled}
 										onclick={() => removeDanmakuUpdateMilestone(index)}>删除</Button
 									>
 								</div>

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -492,6 +492,91 @@
 					<Separator />
 
 					<div class="space-y-4">
+						<div class="flex items-center justify-between">
+							<div class="space-y-1">
+								<Label for="danmaku-update-enabled">弹幕自动更新</Label>
+								<p class="text-muted-foreground text-sm">
+									例如：希望第 3 天更新一次，之后每 7 天更新一次直到第 30 天，可添加“单次：3
+									天”和“周期：截止 30 天，间隔 168 小时”。所有时间均从视频发布时间起算
+								</p>
+							</div>
+							<Switch
+								id="danmaku-update-enabled"
+								bind:checked={formData.danmaku_update_policy.enabled}
+							/>
+						</div>
+
+						<div class="space-y-3">
+							{#each formData.danmaku_update_policy.milestones as milestone, index (index)}
+								<div class="grid grid-cols-1 items-end gap-3 md:grid-cols-[9rem_1fr_1fr_auto]">
+									<div class="space-y-2">
+										<Label for={`danmaku-milestone-type-${index}`}>类型</Label>
+										<select
+											id={`danmaku-milestone-type-${index}`}
+											class="border-input bg-background ring-offset-background focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+											disabled={!formData.danmaku_update_policy.enabled}
+											value={milestone.type}
+											onchange={(event) =>
+												changeDanmakuUpdateMilestoneType(
+													index,
+													event.currentTarget.value as 'once' | 'periodic'
+												)}
+										>
+											<option value="once">单次</option>
+											<option value="periodic">周期</option>
+										</select>
+									</div>
+									{#if milestone.type === 'once'}
+										<div class="space-y-2 md:col-span-2">
+											<Label for={`danmaku-milestone-at-${index}`}>发布时间后第几天</Label>
+											<Input
+												id={`danmaku-milestone-at-${index}`}
+												type="number"
+												min="1"
+												disabled={!formData.danmaku_update_policy.enabled}
+												bind:value={milestone.at_days}
+											/>
+										</div>
+									{:else}
+										<div class="space-y-2">
+											<Label for={`danmaku-milestone-until-${index}`}>截止天数</Label>
+											<Input
+												id={`danmaku-milestone-until-${index}`}
+												type="number"
+												min="1"
+												disabled={!formData.danmaku_update_policy.enabled}
+												bind:value={milestone.until_days}
+											/>
+										</div>
+										<div class="space-y-2">
+											<Label for={`danmaku-milestone-interval-${index}`}>刷新间隔（小时）</Label>
+											<Input
+												id={`danmaku-milestone-interval-${index}`}
+												type="number"
+												min="1"
+												disabled={!formData.danmaku_update_policy.enabled}
+												bind:value={milestone.interval_hours}
+											/>
+										</div>
+									{/if}
+									<Button
+										variant="outline"
+										disabled={!formData.danmaku_update_policy.enabled}
+										onclick={() => removeDanmakuUpdateMilestone(index)}>删除</Button
+									>
+								</div>
+							{/each}
+							<Button
+								variant="outline"
+								disabled={!formData.danmaku_update_policy.enabled}
+								onclick={addDanmakuUpdateMilestone}>添加里程碑</Button
+							>
+						</div>
+					</div>
+
+					<Separator />
+
+					<div class="space-y-4">
 						<Label>处理跳过选项</Label>
 						<p class="text-muted-foreground text-sm">在视频处理部分跳过某些执行环节</p>
 						<div class="flex items-center space-x-2">
@@ -639,90 +724,6 @@
 						<div class="flex items-center space-x-2">
 							<Switch id="danmaku-bold" bind:checked={formData.danmaku_option.bold} />
 							<Label for="danmaku-bold">粗体显示</Label>
-						</div>
-					</div>
-
-					<Separator />
-
-					<div class="space-y-4">
-						<div class="flex items-center justify-between">
-							<div class="space-y-1">
-								<Label for="danmaku-update-enabled">弹幕更新</Label>
-								<p class="text-muted-foreground text-sm">
-									可组合单次里程碑与周期阶段，完成最后一项后停止自动刷新
-								</p>
-							</div>
-							<Switch
-								id="danmaku-update-enabled"
-								bind:checked={formData.danmaku_update_policy.enabled}
-							/>
-						</div>
-
-						<div class="space-y-3">
-							{#each formData.danmaku_update_policy.milestones as milestone, index (index)}
-								<div class="grid grid-cols-1 items-end gap-3 md:grid-cols-[9rem_1fr_1fr_auto]">
-									<div class="space-y-2">
-										<Label for={`danmaku-milestone-type-${index}`}>类型</Label>
-										<select
-											id={`danmaku-milestone-type-${index}`}
-											class="border-input bg-background ring-offset-background focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-											disabled={!formData.danmaku_update_policy.enabled}
-											value={milestone.type}
-											onchange={(event) =>
-												changeDanmakuUpdateMilestoneType(
-													index,
-													event.currentTarget.value as 'once' | 'periodic'
-												)}
-										>
-											<option value="once">单次</option>
-											<option value="periodic">周期</option>
-										</select>
-									</div>
-									{#if milestone.type === 'once'}
-										<div class="space-y-2 md:col-span-2">
-											<Label for={`danmaku-milestone-at-${index}`}>发布时间后第几天</Label>
-											<Input
-												id={`danmaku-milestone-at-${index}`}
-												type="number"
-												min="1"
-												disabled={!formData.danmaku_update_policy.enabled}
-												bind:value={milestone.at_days}
-											/>
-										</div>
-									{:else}
-										<div class="space-y-2">
-											<Label for={`danmaku-milestone-until-${index}`}>截止天数</Label>
-											<Input
-												id={`danmaku-milestone-until-${index}`}
-												type="number"
-												min="1"
-												disabled={!formData.danmaku_update_policy.enabled}
-												bind:value={milestone.until_days}
-											/>
-										</div>
-										<div class="space-y-2">
-											<Label for={`danmaku-milestone-interval-${index}`}>刷新间隔（小时）</Label>
-											<Input
-												id={`danmaku-milestone-interval-${index}`}
-												type="number"
-												min="1"
-												disabled={!formData.danmaku_update_policy.enabled}
-												bind:value={milestone.interval_hours}
-											/>
-										</div>
-									{/if}
-									<Button
-										variant="outline"
-										disabled={!formData.danmaku_update_policy.enabled}
-										onclick={() => removeDanmakuUpdateMilestone(index)}>删除</Button
-									>
-								</div>
-							{/each}
-							<Button
-								variant="outline"
-								disabled={!formData.danmaku_update_policy.enabled}
-								onclick={addDanmakuUpdateMilestone}>添加里程碑</Button
-							>
 						</div>
 					</div>
 				</Tabs.Content>

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -18,7 +18,7 @@
 	import api from '$lib/api';
 	import { toast } from 'svelte-sonner';
 	import { setBreadcrumb } from '$lib/stores/breadcrumb';
-	import type { Config, ApiError, Notifier, Credential } from '$lib/types';
+	import type { Config, ApiError, Notifier, Credential, DanmakuUpdateMilestone } from '$lib/types';
 
 	let frontendToken = ''; // 前端认证token
 	let config: Config | null = null;
@@ -175,6 +175,42 @@
 		} finally {
 			saving = false;
 		}
+	}
+
+	function addDanmakuUpdateMilestone() {
+		if (!formData) return;
+		const milestones = formData.danmaku_update_policy.milestones;
+		const last = milestones[milestones.length - 1];
+		formData.danmaku_update_policy.milestones = [
+			...milestones,
+			{
+				type: 'once',
+				at_days: last ? danmakuUpdateMilestoneEndDays(last) + 30 : 3
+			}
+		];
+	}
+
+	function danmakuUpdateMilestoneEndDays(milestone: DanmakuUpdateMilestone) {
+		return milestone.type === 'once' ? milestone.at_days : milestone.until_days;
+	}
+
+	function changeDanmakuUpdateMilestoneType(index: number, type: 'once' | 'periodic') {
+		if (!formData) return;
+		const milestones = [...formData.danmaku_update_policy.milestones];
+		const current = milestones[index];
+		const endDays = danmakuUpdateMilestoneEndDays(current);
+		milestones[index] =
+			type === 'once'
+				? { type, at_days: endDays }
+				: { type, until_days: endDays, interval_hours: 24 };
+		formData.danmaku_update_policy.milestones = milestones;
+	}
+
+	function removeDanmakuUpdateMilestone(index: number) {
+		if (!formData) return;
+		formData.danmaku_update_policy.milestones = formData.danmaku_update_policy.milestones.filter(
+			(_, milestoneIndex) => milestoneIndex !== index
+		);
 	}
 
 	function handleQrLoginSuccess(credential: Credential) {
@@ -603,6 +639,91 @@
 						<div class="flex items-center space-x-2">
 							<Switch id="danmaku-bold" bind:checked={formData.danmaku_option.bold} />
 							<Label for="danmaku-bold">粗体显示</Label>
+						</div>
+					</div>
+
+					<Separator />
+
+					<div class="space-y-4">
+						<div class="flex items-center justify-between">
+							<div class="space-y-1">
+								<Label for="danmaku-update-enabled">弹幕更新</Label>
+								<p class="text-muted-foreground text-sm">
+									可组合单次里程碑与周期阶段，完成最后一项后停止自动刷新
+								</p>
+							</div>
+							<Switch
+								id="danmaku-update-enabled"
+								bind:checked={formData.danmaku_update_policy.enabled}
+							/>
+						</div>
+
+						<div class="space-y-3">
+							{#each formData.danmaku_update_policy.milestones as milestone, index (index)}
+								<div class="grid grid-cols-1 items-end gap-3 md:grid-cols-[9rem_1fr_1fr_auto]">
+									<div class="space-y-2">
+										<Label for={`danmaku-milestone-type-${index}`}>类型</Label>
+										<select
+											id={`danmaku-milestone-type-${index}`}
+											class="border-input bg-background ring-offset-background focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+											disabled={!formData.danmaku_update_policy.enabled}
+											value={milestone.type}
+											onchange={(event) =>
+												changeDanmakuUpdateMilestoneType(
+													index,
+													event.currentTarget.value as 'once' | 'periodic'
+												)}
+										>
+											<option value="once">单次</option>
+											<option value="periodic">周期</option>
+										</select>
+									</div>
+									{#if milestone.type === 'once'}
+										<div class="space-y-2 md:col-span-2">
+											<Label for={`danmaku-milestone-at-${index}`}>发布时间后第几天</Label>
+											<Input
+												id={`danmaku-milestone-at-${index}`}
+												type="number"
+												min="1"
+												disabled={!formData.danmaku_update_policy.enabled}
+												bind:value={milestone.at_days}
+											/>
+										</div>
+									{:else}
+										<div class="space-y-2">
+											<Label for={`danmaku-milestone-until-${index}`}>截止天数</Label>
+											<Input
+												id={`danmaku-milestone-until-${index}`}
+												type="number"
+												min="1"
+												disabled={!formData.danmaku_update_policy.enabled}
+												bind:value={milestone.until_days}
+											/>
+										</div>
+										<div class="space-y-2">
+											<Label for={`danmaku-milestone-interval-${index}`}>刷新间隔（小时）</Label>
+											<Input
+												id={`danmaku-milestone-interval-${index}`}
+												type="number"
+												min="1"
+												disabled={!formData.danmaku_update_policy.enabled}
+												bind:value={milestone.interval_hours}
+											/>
+										</div>
+									{/if}
+									<Button
+										variant="outline"
+										disabled={!formData.danmaku_update_policy.enabled ||
+											formData.danmaku_update_policy.milestones.length === 1}
+										onclick={() => removeDanmakuUpdateMilestone(index)}>删除</Button
+									>
+								</div>
+							{/each}
+							<Button
+								variant="outline"
+								disabled={!formData.danmaku_update_policy.enabled}
+								onclick={addDanmakuUpdateMilestone}>添加里程碑</Button
+							>
 						</div>
 					</div>
 				</Tabs.Content>


### PR DESCRIPTION
允许用户设置弹幕自动更新策略，这对于 UP 投稿、视频合集/列表比较重要，因为这些视频保存时间仅在投稿时间十几分钟后，几乎不会有足量弹幕填充。

该 PR 引入一种供用户自行配置的弹幕更新机制，作用机制是到达用户配置的检查条件后将 弹幕下载 的子任务标志位重置为”未开始“，这样紧接着的下次下载任务会自然将其补齐。

<img width="1900" height="218" alt="图片" src="https://github.com/user-attachments/assets/84b4570e-09cf-449f-85ed-99bdcdccc6ae" />
