### PR TITLE
feat: 数据库后端支持 PostgreSQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3578,6 +3578,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -3589,6 +3590,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4562,6 +4564,24 @@ name = "webpki-root-certs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,9 @@ rust-embed-for-web = { git = "https://github.com/amtoaer/rust-embed-for-web", ta
 rustls = { version = "0.23.41", default-features = false, features = ["ring"] }
 sea-orm = { version = "1.1.20", features = [
     "macros",
-    "runtime-tokio",
+    "runtime-tokio-rustls",
     "sqlx-sqlite",
+    "sqlx-postgres",
     "sqlite-use-returning-for-3_35",
 ] }
 sea-orm-migration = { version = "1.1.20", features = [] }

--- a/crates/bili_sync/src/api/helper.rs
+++ b/crates/bili_sync/src/api/helper.rs
@@ -35,33 +35,33 @@ impl ValidationFilter {
 }
 
 pub trait VideoRecord {
-    fn as_id_status_tuple(&self) -> (i32, u32);
+    fn as_id_status_tuple(&self) -> (i32, i64);
 }
 
 pub trait PageRecord {
-    fn as_id_status_tuple(&self) -> (i32, u32);
+    fn as_id_status_tuple(&self) -> (i32, i64);
 }
 
 impl VideoRecord for VideoInfo {
-    fn as_id_status_tuple(&self) -> (i32, u32) {
+    fn as_id_status_tuple(&self) -> (i32, i64) {
         (self.id, self.download_status)
     }
 }
 
 impl VideoRecord for SimpleVideoInfo {
-    fn as_id_status_tuple(&self) -> (i32, u32) {
+    fn as_id_status_tuple(&self) -> (i32, i64) {
         (self.id, self.download_status)
     }
 }
 
 impl PageRecord for PageInfo {
-    fn as_id_status_tuple(&self) -> (i32, u32) {
+    fn as_id_status_tuple(&self) -> (i32, i64) {
         (self.id, self.download_status)
     }
 }
 
 impl PageRecord for SimplePageInfo {
-    fn as_id_status_tuple(&self) -> (i32, u32) {
+    fn as_id_status_tuple(&self) -> (i32, i64) {
         (self.id, self.download_status)
     }
 }
@@ -110,7 +110,7 @@ where
 
 async fn execute_video_update_batch(
     txn: &DatabaseTransaction,
-    videos: impl Iterator<Item = (i32, u32)>,
+    videos: impl Iterator<Item = (i32, i64)>,
 ) -> Result<(), sea_orm::DbErr> {
     let values = videos.map(|v| format!("({}, {})", v.0, v.1)).join(", ");
     if values.is_empty() {
@@ -130,7 +130,7 @@ async fn execute_video_update_batch(
 
 async fn execute_page_update_batch(
     txn: &DatabaseTransaction,
-    pages: impl Iterator<Item = (i32, u32)>,
+    pages: impl Iterator<Item = (i32, i64)>,
 ) -> Result<(), sea_orm::DbErr> {
     let values = pages.map(|p| format!("({}, {})", p.0, p.1)).join(", ");
     if values.is_empty() {

--- a/crates/bili_sync/src/api/mod.rs
+++ b/crates/bili_sync/src/api/mod.rs
@@ -1,8 +1,8 @@
 mod error;
 mod helper;
 mod request;
-mod response;
-mod routes;
+pub(crate) mod response;
+pub(crate) mod routes;
 mod wrapper;
 
 pub use routes::{LogHelper, MAX_HISTORY_LOGS, router};

--- a/crates/bili_sync/src/api/request.rs
+++ b/crates/bili_sync/src/api/request.rs
@@ -1,9 +1,19 @@
 use bili_sync_entity::rule::Rule;
 use chrono::NaiveDateTime;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use validator::Validate;
 
 use crate::bilibili::{CollectionType, FilterOption};
+
+/// 反序列化三态 Option：serde derive 对 `Option<Option<T>>` 会把显式 null 折叠成 None，
+/// 用该辅助函数保留区分——字段缺失 → None，显式 null → Some(None)，有值 → Some(Some(v))
+fn deserialize_double_option<'de, D, T>(de: D) -> Result<Option<Option<T>>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Deserialize::deserialize(de).map(Some)
+}
 
 #[derive(Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -144,8 +154,11 @@ pub struct UpdateVideoSourceRequest {
     #[validate(custom(function = "crate::utils::validation::validate_path"))]
     pub path: String,
     pub enabled: bool,
-    pub rule: Option<Rule>,
-    pub filter_option: Option<FilterOption>,
+    /// 外层 Option 区分字段是否提供（缺失不动，显式 null 清空），内层 Option 为实际值
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    pub rule: Option<Option<Rule>>,
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    pub filter_option: Option<Option<FilterOption>>,
     pub use_dynamic_api: Option<bool>,
 }
 
@@ -162,4 +175,43 @@ pub struct PollQrcodeRequest {
 #[derive(Debug, Deserialize)]
 pub struct FullSyncVideoSourceRequest {
     pub delete_local: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 验证 rule/filter_option 的三态语义：字段缺失 → None（不更新），
+    /// 显式 null → Some(None)（清空），有值 → Some(Some(v))（写入）
+    #[test]
+    fn update_video_source_request_rule_semantics() {
+        // 字段缺失 → 不更新
+        let req: UpdateVideoSourceRequest = serde_json::from_value(serde_json::json!({
+            "path": "/tmp",
+            "enabled": true
+        }))
+        .unwrap();
+        assert_eq!(req.rule, None);
+        assert!(matches!(req.filter_option, None));
+
+        // 显式 null → 清空
+        let req: UpdateVideoSourceRequest = serde_json::from_value(serde_json::json!({
+            "path": "/tmp",
+            "enabled": true,
+            "rule": null,
+            "filterOption": null
+        }))
+        .unwrap();
+        assert_eq!(req.rule, Some(None));
+        assert!(matches!(req.filter_option, Some(None)));
+
+        // 有值 → 写入
+        let req: UpdateVideoSourceRequest = serde_json::from_value(serde_json::json!({
+            "path": "/tmp",
+            "enabled": true,
+            "rule": [[{ "field": "title", "rule": { "operator": "equals", "value": "test" } }]]
+        }))
+        .unwrap();
+        assert!(req.rule.as_ref().is_some_and(|rule| rule.is_some()));
+    }
 }

--- a/crates/bili_sync/src/api/response.rs
+++ b/crates/bili_sync/src/api/response.rs
@@ -77,7 +77,7 @@ pub struct VideoInfo {
     pub valid: bool,
     pub should_download: bool,
     #[serde(serialize_with = "serde_video_download_status")]
-    pub download_status: u32,
+    pub download_status: i64,
     pub collection_id: Option<i32>,
     pub favorite_id: Option<i32>,
     pub submission_id: Option<i32>,
@@ -92,14 +92,14 @@ pub struct PageInfo {
     pub pid: i32,
     pub name: String,
     #[serde(serialize_with = "serde_page_download_status")]
-    pub download_status: u32,
+    pub download_status: i64,
 }
 
 #[derive(Serialize, DerivePartialModel, FromQueryResult, Clone, Copy)]
 #[sea_orm(entity = "video::Entity")]
 pub struct SimpleVideoInfo {
     pub id: i32,
-    pub download_status: u32,
+    pub download_status: i64,
 }
 
 #[derive(Serialize, DerivePartialModel, FromQueryResult, Clone, Copy)]
@@ -107,10 +107,10 @@ pub struct SimpleVideoInfo {
 pub struct SimplePageInfo {
     pub id: i32,
     pub video_id: i32,
-    pub download_status: u32,
+    pub download_status: i64,
 }
 
-fn serde_video_download_status<S>(status: &u32, serializer: S) -> Result<S::Ok, S::Error>
+fn serde_video_download_status<S>(status: &i64, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
@@ -118,7 +118,7 @@ where
     status.serialize(serializer)
 }
 
-fn serde_page_download_status<S>(status: &u32, serializer: S) -> Result<S::Ok, S::Error>
+fn serde_page_download_status<S>(status: &i64, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
@@ -180,7 +180,7 @@ pub struct VideoSourcesDetailsResponse {
     pub watch_later: Vec<VideoSourceDetail>,
 }
 
-#[derive(Serialize, FromQueryResult)]
+#[derive(Debug, Serialize, FromQueryResult)]
 pub struct DayCountPair {
     pub day: String,
     pub cnt: i64,

--- a/crates/bili_sync/src/api/routes/dashboard/mod.rs
+++ b/crates/bili_sync/src/api/routes/dashboard/mod.rs
@@ -2,10 +2,11 @@ use axum::routing::get;
 use axum::{Extension, Router};
 use bili_sync_entity::*;
 use sea_orm::entity::prelude::*;
-use sea_orm::{FromQueryResult, Statement};
+use sea_orm::{DatabaseBackend, FromQueryResult, Statement};
 
 use crate::api::response::{DashBoardResponse, DayCountPair};
 use crate::api::wrapper::{ApiError, ApiResponse};
+use crate::utils::time::last_seven_local_days;
 
 pub(super) fn router() -> Router {
     Router::new().route("/dashboard", get(get_dashboard))
@@ -29,8 +30,27 @@ async fn get_dashboard(
             .count(&db),
         DayCountPair::find_by_statement(Statement::from_string(
             db.get_database_backend(),
-            // 用 SeaORM 太复杂了，直接写个裸 SQL
-            "
+            dashboard_day_count_sql(db.get_database_backend()),
+        ))
+        .all(&db),
+    )?;
+    Ok(ApiResponse::ok(DashBoardResponse {
+        enabled_favorites,
+        enabled_collections,
+        enabled_submissions,
+        enable_watch_later: enabled_watch_later > 0,
+        videos_by_day,
+    }))
+}
+
+/// 按天统计最近 7 天新增视频数。两种后端均以 UTC 存储 created_at：
+/// SQLite 在 SQL 内换算本地时间，PostgreSQL 的日期边界在应用侧按服务器
+/// 本地时区计算后内联进 SQL（与 SQLite 的 localtime 语义一致；SQLite 按当前
+/// 偏移换算、PG 按历史偏移换算，DST 过渡窗口内两后端日界可能相差至多 1 小时，
+/// PG 侧按日历日语义更精确）
+pub(crate) fn dashboard_day_count_sql(backend: DatabaseBackend) -> String {
+    match backend {
+        DatabaseBackend::Sqlite => "
 SELECT
     dates.day AS day,
     COUNT(video.id) AS cnt
@@ -52,14 +72,35 @@ GROUP BY
 ORDER BY
     dates.day;
     "
-        ))
-        .all(&db),
-    )?;
-    Ok(ApiResponse::ok(DashBoardResponse {
-        enabled_favorites,
-        enabled_collections,
-        enabled_submissions,
-        enable_watch_later: enabled_watch_later > 0,
-        videos_by_day,
-    }))
+        .to_string(),
+        DatabaseBackend::Postgres => {
+            let values = last_seven_local_days()
+                .iter()
+                .map(|(day, start, end)| {
+                    format!(
+                        "('{day}', '{}'::timestamp, '{}'::timestamp)",
+                        start.format("%Y-%m-%d %H:%M:%S"),
+                        end.format("%Y-%m-%d %H:%M:%S"),
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+            format!(
+                "SELECT
+    dates.day AS day,
+    COUNT(video.id) AS cnt
+FROM
+    (
+        SELECT * FROM (VALUES {values}) AS v(day, start_utc_datetime, end_utc_datetime)
+    ) AS dates
+LEFT JOIN
+    video ON video.created_at >= dates.start_utc_datetime AND video.created_at < dates.end_utc_datetime
+GROUP BY
+    dates.day
+ORDER BY
+    dates.day;"
+            )
+        }
+        _ => unreachable!(),
+    }
 }

--- a/crates/bili_sync/src/api/routes/mod.rs
+++ b/crates/bili_sync/src/api/routes/mod.rs
@@ -11,7 +11,7 @@ use crate::api::wrapper::ApiResponse;
 use crate::config::VersionedConfig;
 
 mod config;
-mod dashboard;
+pub(crate) mod dashboard;
 mod login;
 mod me;
 mod task;

--- a/crates/bili_sync/src/api/routes/video_sources/mod.rs
+++ b/crates/bili_sync/src/api/routes/video_sources/mod.rs
@@ -202,31 +202,49 @@ pub async fn update_video_source(
     Extension(db): Extension<DatabaseConnection>,
     ValidatedJson(request): ValidatedJson<UpdateVideoSourceRequest>,
 ) -> Result<ApiResponse<UpdateVideoSourceResponse>, ApiError> {
-    let rule_display = request.rule.as_ref().map(|rule| rule.to_string());
-    let filter_option = request.filter_option.map(serde_json::to_value).transpose()?;
+    let filter_option = request
+        .filter_option
+        .as_ref()
+        .map(|opt| opt.as_ref().map(serde_json::to_value).transpose())
+        .transpose()?; // Option<Option<Value>>，外层区分是否提供，内层为实际值
     let active_model = match source_type.as_str() {
         "collections" => collection::Entity::find_by_id(id).one(&db).await?.map(|model| {
             let mut active_model: collection::ActiveModel = model.into();
             active_model.path = Set(request.path);
             active_model.enabled = Set(request.enabled);
-            active_model.rule = Set(request.rule);
-            active_model.filter_option = Set(filter_option);
+            // rule/filter_option 仅在请求中提供时更新：提供 null 表示清空，缺失表示不更新
+            if let Some(rule) = request.rule {
+                active_model.rule = Set(rule);
+            }
+            if let Some(filter_option) = filter_option {
+                active_model.filter_option = Set(filter_option);
+            }
             _ActiveModel::Collection(active_model)
         }),
         "favorites" => favorite::Entity::find_by_id(id).one(&db).await?.map(|model| {
             let mut active_model: favorite::ActiveModel = model.into();
             active_model.path = Set(request.path);
             active_model.enabled = Set(request.enabled);
-            active_model.rule = Set(request.rule);
-            active_model.filter_option = Set(filter_option);
+            // rule/filter_option 仅在请求中提供时更新：提供 null 表示清空，缺失表示不更新
+            if let Some(rule) = request.rule {
+                active_model.rule = Set(rule);
+            }
+            if let Some(filter_option) = filter_option {
+                active_model.filter_option = Set(filter_option);
+            }
             _ActiveModel::Favorite(active_model)
         }),
         "submissions" => submission::Entity::find_by_id(id).one(&db).await?.map(|model| {
             let mut active_model: submission::ActiveModel = model.into();
             active_model.path = Set(request.path);
             active_model.enabled = Set(request.enabled);
-            active_model.rule = Set(request.rule);
-            active_model.filter_option = Set(filter_option);
+            // rule/filter_option 仅在请求中提供时更新：提供 null 表示清空，缺失表示不更新
+            if let Some(rule) = request.rule {
+                active_model.rule = Set(rule);
+            }
+            if let Some(filter_option) = filter_option {
+                active_model.filter_option = Set(filter_option);
+            }
             if let Some(use_dynamic_api) = request.use_dynamic_api {
                 active_model.use_dynamic_api = Set(use_dynamic_api);
             }
@@ -240,8 +258,13 @@ pub async fn update_video_source(
                 let mut active_model: watch_later::ActiveModel = model.into();
                 active_model.path = Set(request.path);
                 active_model.enabled = Set(request.enabled);
-                active_model.rule = Set(request.rule);
-                active_model.filter_option = Set(filter_option);
+                // rule/filter_option 仅在请求中提供时更新：提供 null 表示清空，缺失表示不更新
+                if let Some(rule) = request.rule {
+                    active_model.rule = Set(rule);
+                }
+                if let Some(filter_option) = filter_option {
+                    active_model.filter_option = Set(filter_option);
+                }
                 Some(_ActiveModel::WatchLater(active_model))
             }
             None => {
@@ -252,8 +275,8 @@ pub async fn update_video_source(
                     Some(_ActiveModel::WatchLater(watch_later::ActiveModel {
                         path: Set(request.path),
                         enabled: Set(request.enabled),
-                        rule: Set(request.rule),
-                        filter_option: Set(filter_option),
+                        rule: Set(request.rule.flatten()),
+                        filter_option: Set(filter_option.flatten()),
                         ..Default::default()
                     }))
                 }
@@ -264,8 +287,22 @@ pub async fn update_video_source(
     let Some(active_model) = active_model else {
         return Err(InnerApiError::NotFound(id).into());
     };
+    // rule_display 从待持久化的 active_model 计算：请求未携带 rule 时沿用模型中的已有
+    // 规则，直接取请求值会把「缺失=不更新」误报成「规则已清空」
+    let rule_display = active_model_rule(&active_model).map(|rule| rule.to_string());
     active_model.save(&db).await?;
     Ok(ApiResponse::ok(UpdateVideoSourceResponse { rule_display }))
+}
+
+/// 取出视频源 ActiveModel 的 rule 字段（已包含请求中的更新）：模型转 ActiveModel 时
+/// 所有字段均为 Set，请求未携带 rule 时即为原有规则，与 save 后回查数据库结果一致
+fn active_model_rule(active_model: &_ActiveModel) -> Option<&Rule> {
+    match active_model {
+        _ActiveModel::Collection(am) => am.rule.as_ref().as_ref(),
+        _ActiveModel::Favorite(am) => am.rule.as_ref().as_ref(),
+        _ActiveModel::Submission(am) => am.rule.as_ref().as_ref(),
+        _ActiveModel::WatchLater(am) => am.rule.as_ref().as_ref(),
+    }
 }
 
 pub async fn remove_video_source(

--- a/crates/bili_sync/src/api/routes/videos/mod.rs
+++ b/crates/bili_sync/src/api/routes/videos/mod.rs
@@ -9,8 +9,8 @@ use chrono::NaiveDateTime;
 use sea_orm::ActiveValue::Set;
 use sea_orm::sea_query::{Expr, ExprTrait};
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel, PaginatorTrait, QueryFilter,
-    QueryOrder, Select, TransactionTrait, TryIntoModel,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseBackend, DatabaseConnection, EntityTrait, IntoActiveModel,
+    PaginatorTrait, QueryFilter, QueryOrder, Select, TransactionTrait, TryIntoModel,
 };
 
 use crate::api::error::InnerApiError;
@@ -26,6 +26,7 @@ use crate::api::response::{
 };
 use crate::api::wrapper::{ApiError, ApiResponse, ValidatedJson};
 use crate::utils::status::{PageStatus, VideoStatus};
+use crate::utils::time::local_to_utc;
 
 pub(super) fn router() -> Router {
     Router::new()
@@ -42,21 +43,34 @@ pub(super) fn router() -> Router {
 }
 
 fn apply_created_at_filter(
+    db: &DatabaseConnection,
     mut query: Select<video::Entity>,
     created_from: Option<NaiveDateTime>,
     created_to: Option<NaiveDateTime>,
 ) -> Select<video::Entity> {
+    // 两种后端均以 UTC 存储 created_at。SQLite 在 SQL 内用 datetime(?, 'localtime')
+    // 转换到本地时间；PostgreSQL 在应用侧按服务器本地时区换算参数后直接比较，语义一致
+    // （SQLite 按查询时刻的当前偏移换算，PG 按目标日期的历史偏移换算，DST 过渡窗口内
+    // 两后端边界可能相差至多 1 小时，PG 侧更精确）
     if let Some(created_from) = created_from {
-        query = query.filter(
-            Expr::cust_with_expr("datetime(?, 'localtime')", Expr::col(video::Column::CreatedAt))
-                .gte(created_from.format("%Y-%m-%d %H:%M:%S").to_string()),
-        );
+        query = match db.get_database_backend() {
+            DatabaseBackend::Sqlite => query.filter(
+                Expr::cust_with_expr("datetime(?, 'localtime')", Expr::col(video::Column::CreatedAt))
+                    .gte(created_from.format("%Y-%m-%d %H:%M:%S").to_string()),
+            ),
+            DatabaseBackend::Postgres => query.filter(video::Column::CreatedAt.gte(local_to_utc(created_from, false))),
+            _ => unreachable!(),
+        };
     }
     if let Some(created_to) = created_to {
-        query = query.filter(
-            Expr::cust_with_expr("datetime(?, 'localtime')", Expr::col(video::Column::CreatedAt))
-                .lte(created_to.format("%Y-%m-%d %H:%M:%S").to_string()),
-        );
+        query = match db.get_database_backend() {
+            DatabaseBackend::Sqlite => query.filter(
+                Expr::cust_with_expr("datetime(?, 'localtime')", Expr::col(video::Column::CreatedAt))
+                    .lte(created_to.format("%Y-%m-%d %H:%M:%S").to_string()),
+            ),
+            DatabaseBackend::Postgres => query.filter(video::Column::CreatedAt.lte(local_to_utc(created_to, true))),
+            _ => unreachable!(),
+        };
     }
     query
 }
@@ -90,7 +104,7 @@ pub async fn get_videos(
     if let Some(validation_filter) = params.validation_filter {
         query = query.filter(validation_filter.to_video_query());
     }
-    query = apply_created_at_filter(query, params.created_from, params.created_to);
+    query = apply_created_at_filter(&db, query, params.created_from, params.created_to);
     let total_count = query.clone().count(&db).await?;
     let (page, page_size) = if let (Some(page), Some(page_size)) = (params.page, params.page_size) {
         (page, page_size)
@@ -150,7 +164,7 @@ pub async fn reset_video_status(
         .filter_map(|mut page_info| {
             let mut page_status = PageStatus::from(page_info.download_status);
             if (request.force && page_status.force_reset_failed()) || page_status.reset_failed() {
-                page_info.download_status = page_status.into();
+                page_info.download_status = i64::from(page_status);
                 Some(page_info)
             } else {
                 None
@@ -164,7 +178,7 @@ pub async fn reset_video_status(
         video_resetted = true;
     }
     let resetted_videos_info = if video_resetted {
-        video_info.download_status = video_status.into();
+        video_info.download_status = i64::from(video_status);
         vec![&video_info]
     } else {
         vec![]
@@ -263,7 +277,7 @@ pub async fn reset_filtered_video_status(
     if let Some(validation_filter) = request.validation_filter {
         query = query.filter(validation_filter.to_video_query());
     }
-    query = apply_created_at_filter(query, request.created_from, request.created_to);
+    query = apply_created_at_filter(&db, query, request.created_from, request.created_to);
     let all_videos = query.into_partial_model::<SimpleVideoInfo>().all(&db).await?;
     let all_pages = page::Entity::find()
         .filter(page::Column::VideoId.is_in(all_videos.iter().map(|v| v.id)))
@@ -275,7 +289,7 @@ pub async fn reset_filtered_video_status(
         .filter_map(|mut page_info| {
             let mut page_status = PageStatus::from(page_info.download_status);
             if (request.force && page_status.force_reset_failed()) || page_status.reset_failed() {
-                page_info.download_status = page_status.into();
+                page_info.download_status = i64::from(page_status);
                 Some(page_info)
             } else {
                 None
@@ -294,7 +308,7 @@ pub async fn reset_filtered_video_status(
                 video_resetted = true;
             }
             if video_resetted {
-                video_info.download_status = video_status.into();
+                video_info.download_status = i64::from(video_status);
                 Some(video_info)
             } else {
                 None
@@ -340,7 +354,7 @@ pub async fn update_video_status(
     for update in &request.video_updates {
         video_status.set(update.status_index, update.status_value);
     }
-    video_info.download_status = video_status.into();
+    video_info.download_status = i64::from(video_status);
     let mut updated_pages_info = Vec::new();
     let mut page_id_map = pages_info
         .iter_mut()
@@ -352,7 +366,7 @@ pub async fn update_video_status(
             for update in &page_update.updates {
                 page_status.set(update.status_index, update.status_value);
             }
-            page_info.download_status = page_status.into();
+            page_info.download_status = i64::from(page_status);
             updated_pages_info.push(page_info);
         }
     }
@@ -403,7 +417,7 @@ pub async fn update_filtered_video_status(
     if let Some(validation_filter) = request.validation_filter {
         query = query.filter(validation_filter.to_video_query());
     }
-    query = apply_created_at_filter(query, request.created_from, request.created_to);
+    query = apply_created_at_filter(&db, query, request.created_from, request.created_to);
     let mut all_videos = query.into_partial_model::<SimpleVideoInfo>().all(&db).await?;
     let mut all_pages = page::Entity::find()
         .filter(page::Column::VideoId.is_in(all_videos.iter().map(|v| v.id)))
@@ -415,14 +429,14 @@ pub async fn update_filtered_video_status(
         for update in &request.video_updates {
             video_status.set(update.status_index, update.status_value);
         }
-        video_info.download_status = video_status.into();
+        video_info.download_status = i64::from(video_status);
     }
     for page_info in all_pages.iter_mut() {
         let mut page_status = PageStatus::from(page_info.download_status);
         for update in &request.page_updates {
             page_status.set(update.status_index, update.status_value);
         }
-        page_info.download_status = page_status.into();
+        page_info.download_status = i64::from(page_status);
     }
     let has_video_updates = !all_videos.is_empty();
     let has_page_updates = !all_pages.is_empty();

--- a/crates/bili_sync/src/bilibili/mod.rs
+++ b/crates/bili_sync/src/bilibili/mod.rs
@@ -232,13 +232,13 @@ mod tests {
     use super::*;
     use crate::bilibili::credential::WbiImg;
     use crate::config::VersionedConfig;
-    use crate::database::setup_database;
+    use crate::database::{database_url, setup_database};
     use crate::utils::init_logger;
 
     #[ignore = "only for manual test"]
     #[tokio::test]
     async fn test_video_info_type() -> Result<()> {
-        VersionedConfig::init_for_test(&setup_database(Path::new("./test.sqlite")).await?).await?;
+        VersionedConfig::init_for_test(&setup_database(&database_url(Path::new("./test.sqlite"))).await?).await?;
         let credential = &VersionedConfig::get().read().credential;
         init_logger("None,bili_sync=debug", None);
         let bili_client = BiliClient::new();
@@ -312,7 +312,7 @@ mod tests {
     #[ignore = "only for manual test"]
     #[tokio::test]
     async fn test_subtitle_parse() -> Result<()> {
-        VersionedConfig::init_for_test(&setup_database(Path::new("./test.sqlite")).await?).await?;
+        VersionedConfig::init_for_test(&setup_database(&database_url(Path::new("./test.sqlite"))).await?).await?;
         let credential = &VersionedConfig::get().read().credential;
         let bili_client = BiliClient::new();
         let mixin_key = bili_client
@@ -338,7 +338,7 @@ mod tests {
     #[ignore = "only for manual test"]
     #[tokio::test]
     async fn test_upower_parse() -> Result<()> {
-        VersionedConfig::init_for_test(&setup_database(Path::new("./test.sqlite")).await?).await?;
+        VersionedConfig::init_for_test(&setup_database(&database_url(Path::new("./test.sqlite"))).await?).await?;
         let credential = &VersionedConfig::get().read().credential;
         let bili_client = BiliClient::new();
         let mixin_key = bili_client
@@ -371,7 +371,7 @@ mod tests {
     #[ignore = "only for manual test"]
     #[tokio::test]
     async fn test_ep_parse() -> Result<()> {
-        VersionedConfig::init_for_test(&setup_database(Path::new("./test.sqlite")).await?).await?;
+        VersionedConfig::init_for_test(&setup_database(&database_url(Path::new("./test.sqlite"))).await?).await?;
         let credential = &VersionedConfig::get().read().credential;
         let bili_client = BiliClient::new();
         let mixin_key = bili_client

--- a/crates/bili_sync/src/config/args.rs
+++ b/crates/bili_sync/src/config/args.rs
@@ -23,6 +23,9 @@ pub struct Args {
 
     #[arg(short, long, env = "BILI_SYNC_FFMPEG_PATH")]
     pub ffmpeg_path: Option<String>,
+
+    #[arg(long, env = "BILI_SYNC_DATABASE_URL", help = "数据库连接串，支持 sqlite:// 与 postgres://")]
+    pub database_url: Option<String>,
 }
 
 mod built_info {

--- a/crates/bili_sync/src/database.rs
+++ b/crates/bili_sync/src/database.rs
@@ -3,11 +3,15 @@ use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use bili_sync_migration::{Migrator, MigratorTrait};
+use sea_orm::sqlx::postgres::PgConnectOptions;
 use sea_orm::sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqliteSynchronous};
-use sea_orm::sqlx::{ConnectOptions as SqlxConnectOptions, Sqlite};
-use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection, SqlxSqliteConnector, Statement};
+use sea_orm::sqlx::{ConnectOptions as SqlxConnectOptions, Postgres, Sqlite};
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseBackend, DatabaseConnection, SqlxPostgresConnector,
+    SqlxSqliteConnector, Statement,
+};
 
-fn database_url(path: &Path) -> String {
+pub fn database_url(path: &Path) -> String {
     format!("sqlite://{}?mode=rwc", path.to_string_lossy())
 }
 
@@ -17,21 +21,43 @@ async fn database_connection(database_url: &str) -> Result<DatabaseConnection> {
         .max_connections(50)
         .min_connections(5)
         .acquire_timeout(Duration::from_secs(90));
-    let connect_option = option
-        .get_url()
-        .parse::<SqliteConnectOptions>()
-        .context("Failed to parse database URL")?
-        .disable_statement_logging()
-        .busy_timeout(Duration::from_secs(90))
-        .journal_mode(SqliteJournalMode::Wal)
-        .synchronous(SqliteSynchronous::Normal)
-        .optimize_on_close(true, None);
-    Ok(SqlxSqliteConnector::from_sqlx_sqlite_pool(
-        option
-            .sqlx_pool_options::<Sqlite>()
-            .connect_with(connect_option)
-            .await?,
-    ))
+    // 按 scheme 区分后端：覆盖 sqlite: 与 sqlite:// 两种写法，其余按 PostgreSQL 解析
+    // scheme 按 RFC 3986 大小写不敏感，先统一转小写再判定，避免 SQLite:// 之类写法被误路由
+    let scheme = database_url.split(':').next().unwrap_or_default().to_ascii_lowercase();
+    if scheme == "sqlite" {
+        let connect_option = option
+            .get_url()
+            .parse::<SqliteConnectOptions>()
+            .context("Failed to parse database URL")?
+            .disable_statement_logging()
+            .busy_timeout(Duration::from_secs(90))
+            .journal_mode(SqliteJournalMode::Wal)
+            .synchronous(SqliteSynchronous::Normal)
+            .optimize_on_close(true, None);
+        Ok(SqlxSqliteConnector::from_sqlx_sqlite_pool(
+            option
+                .sqlx_pool_options::<Sqlite>()
+                .connect_with(connect_option)
+                .await?,
+        ))
+    } else {
+        // sqlx 的 PgConnectOptions 不校验 scheme，任意非 sqlite URL 都会按 PG 解析，
+        // 显式校验避免 mysql:// 之类连接串得到费解的握手错误
+        if !matches!(scheme.as_str(), "postgres" | "postgresql") {
+            bail!("不支持的数据库 scheme，仅支持 sqlite:// 与 postgres:// 两种连接串");
+        }
+        let connect_option = option
+            .get_url()
+            .parse::<PgConnectOptions>()
+            .context("Failed to parse database URL")?
+            .disable_statement_logging();
+        Ok(SqlxPostgresConnector::from_sqlx_postgres_pool(
+            option
+                .sqlx_pool_options::<Postgres>()
+                .connect_with(connect_option)
+                .await?,
+        ))
+    }
 }
 
 async fn migrate_database(database_url: &str) -> Result<()> {
@@ -40,13 +66,15 @@ async fn migrate_database(database_url: &str) -> Result<()> {
     let connection = Database::connect(database_url).await?;
     // 避免 https://github.com/amtoaer/bili-sync/issues/571 问题，迁移前根据 migration 确认当前版本
     // 如果用户从 2.6.0 以下版本直接升级，migration 不满足需求，直接报错而不执行迁移
-    if connection
-        .query_one(Statement::from_string(
-            connection.get_database_backend(),
-            "SELECT 1 FROM seaql_migrations WHERE version = 'm20250613_043257_add_config';",
-        ))
-        .await
-        .is_ok_and(|res| res.is_none())
+    // 版本守卫仅对 SQLite 生效：PostgreSQL 总是全新安装，不存在从旧版本升级的问题
+    if matches!(connection.get_database_backend(), DatabaseBackend::Sqlite)
+        && connection
+            .query_one(Statement::from_string(
+                connection.get_database_backend(),
+                "SELECT 1 FROM seaql_migrations WHERE version = 'm20250613_043257_add_config';",
+            ))
+            .await
+            .is_ok_and(|res| res.is_none())
     {
         // 查询成功且结果为空，即没有 m20250613_043257_add_config，说明版本低于 2.6.0
         bail!("该版本仅支持从 2.6.x 以上的版本升级，请先升级至 2.6.x 或 2.7.x 完成配置迁移，再升级至最新版本。");
@@ -55,17 +83,105 @@ async fn migrate_database(database_url: &str) -> Result<()> {
 }
 
 /// 进行数据库迁移并获取数据库连接，供外部使用
-pub async fn setup_database(path: &Path) -> Result<DatabaseConnection> {
-    if let Some(parent) = path.parent() {
+pub async fn setup_database(database_url: &str) -> Result<DatabaseConnection> {
+    // 仅 SQLite 需要预先创建数据库文件所在的目录
+    if let Some(path) = sqlite_path_from_url(database_url)
+        && let Some(parent) = path.parent()
+        // 相对路径（如 sqlite:data.sqlite）或内存库（:memory:）没有父目录，跳过
+        && !parent.as_os_str().is_empty()
+    {
         tokio::fs::create_dir_all(parent).await.context(
             "Failed to create config directory. Please check if you have granted necessary permissions to your folder.",
         )?;
     }
-    let database_url = database_url(path);
-    migrate_database(&database_url)
+    migrate_database(database_url)
         .await
         .context("Failed to migrate database")?;
-    database_connection(&database_url)
+    database_connection(database_url)
         .await
         .context("Failed to connect to database")
+}
+
+fn sqlite_path_from_url(url: &str) -> Option<&Path> {
+    // sqlx 接受 sqlite: 与 sqlite:// 两种写法，两者都需要预创建父目录
+    url.strip_prefix("sqlite://")
+        .or_else(|| url.strip_prefix("sqlite:"))
+        .map(|rest| rest.split('?').next().unwrap_or(rest))
+        .map(Path::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDateTime;
+    use sea_orm::ActiveValue::Set;
+    use sea_orm::{ColumnTrait, EntityTrait, FromQueryResult, PaginatorTrait, QueryFilter};
+
+    use super::*;
+    use crate::api::response::DayCountPair;
+    use crate::api::routes::dashboard::dashboard_day_count_sql;
+
+    /// SQLite 回归测试：覆盖 created_at 由 CURRENT_TIMESTAMP 默认值写入、实体按
+    /// DateTime 解码（UTC 语义）以及 dashboard SQL 的 SQLite 分支——这些路径不依赖
+    /// PostgreSQL，常驻运行作为升级兼容性的护栏
+    #[tokio::test]
+    async fn test_sqlite_created_at_and_dashboard() -> Result<()> {
+        let dir = std::env::temp_dir().join(format!("bili-sync-test-{}", std::process::id()));
+        tokio::fs::create_dir_all(&dir).await?;
+        let url = database_url(&dir.join("test.sqlite"));
+        let connection = setup_database(&url).await?;
+        // 清理上次运行遗留的测试数据（临时目录按 PID 命名，进程被杀后可能残留）
+        bili_sync_entity::video::Entity::delete_many()
+            .filter(bili_sync_entity::video::Column::Bvid.eq("BV1sqlite00001"))
+            .exec(&connection)
+            .await?;
+        let timestamp = NaiveDateTime::parse_from_str("2024-01-01 00:00:00", "%Y-%m-%d %H:%M:%S")?;
+        // created_at 不显式赋值，由 CURRENT_TIMESTAMP 默认值写入
+        let insert_result = bili_sync_entity::video::Entity::insert(bili_sync_entity::video::ActiveModel {
+            upper_id: Set(1),
+            upper_name: Set("测试".to_string()),
+            upper_face: Set("".to_string()),
+            name: Set("测试视频".to_string()),
+            path: Set("/tmp/bili-sync-sqlite-regression".to_string()),
+            category: Set(2),
+            bvid: Set("BV1sqlite00001".to_string()),
+            intro: Set("".to_string()),
+            cover: Set("".to_string()),
+            ctime: Set(timestamp),
+            pubtime: Set(timestamp),
+            favtime: Set(timestamp),
+            download_status: Set(0),
+            valid: Set(true),
+            should_download: Set(true),
+            ..Default::default()
+        })
+        .exec(&connection)
+        .await?;
+        let video_id = insert_result.last_insert_id;
+        // 读回验证 DateTime 解码与 UTC 语义
+        let model = bili_sync_entity::video::Entity::find_by_id(video_id as i32)
+            .one(&connection)
+            .await?
+            .expect("视频应当存在");
+        let delta_minutes = (chrono::Utc::now().naive_utc() - model.created_at).num_minutes().abs();
+        assert!(
+            delta_minutes < 10,
+            "created_at 应解码为 UTC，与 UTC 相差 {delta_minutes} 分钟"
+        );
+        // dashboard SQLite 分支返回最近 7 天且今日计数包含刚插入的视频
+        let day_counts = DayCountPair::find_by_statement(Statement::from_string(
+            connection.get_database_backend(),
+            dashboard_day_count_sql(connection.get_database_backend()),
+        ))
+        .all(&connection)
+        .await?;
+        assert_eq!(day_counts.len(), 7, "dashboard 应返回最近 7 天");
+        let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+        assert!(
+            day_counts.iter().any(|day| day.day == today && day.cnt >= 1),
+            "今日应有至少 1 条新增视频，实际为 {day_counts:?}"
+        );
+        connection.close().await?;
+        tokio::fs::remove_dir_all(&dir).await?;
+        Ok(())
+    }
 }

--- a/crates/bili_sync/src/downloader.rs
+++ b/crates/bili_sync/src/downloader.rs
@@ -301,13 +301,13 @@ mod tests {
 
     use crate::bilibili::{BestStream, BiliClient, Video};
     use crate::config::VersionedConfig;
-    use crate::database::setup_database;
+    use crate::database::{database_url, setup_database};
     use crate::downloader::Downloader;
 
     #[ignore = "only for manual test"]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_parse_and_download_video() -> Result<()> {
-        VersionedConfig::init_for_test(&setup_database(Path::new("./test.sqlite")).await?).await?;
+        VersionedConfig::init_for_test(&setup_database(&database_url(Path::new("./test.sqlite"))).await?).await?;
         let config = VersionedConfig::get().read();
         let client = BiliClient::new();
         let video = Video::new(&client, "BV1QJmaYKEv4", &config.credential);

--- a/crates/bili_sync/src/main.rs
+++ b/crates/bili_sync/src/main.rs
@@ -104,9 +104,11 @@ async fn init() -> Result<(Arc<BiliClient>, DatabaseConnection, LogHelper)> {
         bail!("ffmpeg 不存在或无法执行，请确保已正确安装 ffmpeg，并且 {ffmpeg_path} 命令可用");
     }
 
-    let connection = setup_database(&CONFIG_DIR.join("data.sqlite"))
-        .await
-        .context("数据库初始化失败")?;
+    let database_url = ARGS
+        .database_url
+        .clone()
+        .unwrap_or_else(|| database::database_url(&CONFIG_DIR.join("data.sqlite")));
+    let connection = setup_database(&database_url).await.context("数据库初始化失败")?;
     info!("数据库初始化完成");
     VersionedConfig::init(&connection).await.context("配置初始化失败")?;
     info!("配置初始化完成");

--- a/crates/bili_sync/src/utils/convert.rs
+++ b/crates/bili_sync/src/utils/convert.rs
@@ -202,9 +202,9 @@ impl PageInfo {
         let (width, height) = match &self.dimension {
             Some(d) => {
                 if d.rotate == 0 {
-                    (Some(d.width), Some(d.height))
+                    (Some(d.width as i32), Some(d.height as i32))
                 } else {
-                    (Some(d.height), Some(d.width))
+                    (Some(d.height as i32), Some(d.width as i32))
                 }
             }
             None => (None, None),
@@ -216,7 +216,7 @@ impl PageInfo {
             name: Set(self.name),
             width: Set(width),
             height: Set(height),
-            duration: Set(self.duration),
+            duration: Set(self.duration as i32),
             image: Set(self.first_frame),
             download_status: Set(0),
             ..Default::default()

--- a/crates/bili_sync/src/utils/mod.rs
+++ b/crates/bili_sync/src/utils/mod.rs
@@ -8,6 +8,7 @@ pub mod notify;
 pub mod rule;
 pub mod signal;
 pub mod status;
+pub mod time;
 pub mod validation;
 use tracing_subscriber::fmt;
 use tracing_subscriber::layer::SubscriberExt;

--- a/crates/bili_sync/src/utils/model.rs
+++ b/crates/bili_sync/src/utils/model.rs
@@ -5,7 +5,7 @@ use rand::seq::SliceRandom;
 use sea_orm::ActiveValue::Set;
 use sea_orm::entity::prelude::*;
 use sea_orm::sea_query::{Expr, OnConflict, SimpleExpr};
-use sea_orm::{ConnectionTrait, DatabaseTransaction, IdenStatic, Statement};
+use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseTransaction, IdenStatic, Statement};
 
 use crate::adapter::{VideoSource, VideoSourceEnum};
 use crate::bilibili::VideoInfo;
@@ -40,7 +40,7 @@ pub async fn filter_unhandled_video_pages(
         .filter(
             video::Column::Valid
                 .eq(true)
-                .and(video::Column::DownloadStatus.lt(STATUS_COMPLETED))
+                .and(video::Column::DownloadStatus.lt(i64::from(STATUS_COMPLETED)))
                 .and(video::Column::Category.eq(2))
                 .and(video::Column::SinglePage.is_not_null())
                 .and(video::Column::ShouldDownload.eq(true))
@@ -130,9 +130,29 @@ pub async fn update_video_detail_models(
         video::Column::Tags,
         video::Column::SinglePage,
     ];
-    let row = format!("({})", std::iter::repeat_n("?", columns.len()).join(", "));
-    let rows = std::iter::repeat_n(row.as_str(), videos.len()).join(", ");
-    let mut values = Vec::with_capacity(videos.len() * columns.len());
+    let video_count = videos.len();
+    // SQLite 使用 ? 占位符；PostgreSQL 使用 $n 占位符，且需要为 VALUES 各列显式标注类型
+    let rows = match connection.get_database_backend() {
+        DatabaseBackend::Sqlite => {
+            let row = format!("({})", std::iter::repeat_n("?", columns.len()).join(", "));
+            std::iter::repeat_n(row.as_str(), video_count).join(", ")
+        }
+        DatabaseBackend::Postgres => (0..video_count)
+            .map(|row_index| {
+                let offset = row_index * columns.len();
+                let row = columns
+                    .iter()
+                    .enumerate()
+                    .map(|(i, column)| format!("${}::{}", offset + i + 1, pg_param_type(*column)))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("({row})")
+            })
+            .collect::<Vec<_>>()
+            .join(", "),
+        _ => unreachable!(),
+    };
+    let mut values = Vec::with_capacity(video_count * columns.len());
     for video in videos {
         for column in columns {
             values.push(
@@ -144,19 +164,18 @@ pub async fn update_video_detail_models(
         }
     }
     let sql = format!(
-        "WITH tempdata({}) AS (VALUES {}) \
+        "WITH tempdata({}) AS (VALUES {rows}) \
         UPDATE video \
         SET {} \
         FROM tempdata \
         WHERE video.id = tempdata.id",
         columns.iter().map(IdenStatic::as_str).join(", "),
-        rows,
         columns
             .iter()
             .skip(1)
             .map(|column| {
                 let column = column.as_str();
-                format!("{} = tempdata.{}", column, column)
+                format!("{column} = tempdata.{column}")
             })
             .join(", ")
     );
@@ -168,6 +187,26 @@ pub async fn update_video_detail_models(
         ))
         .await?;
     Ok(())
+}
+
+/// PostgreSQL 批量更新的 VALUES 子句需要为每个占位符显式标注类型。
+/// 按列名派生而不是维护与 columns 平行的类型数组：未来往 columns 中新增列时，
+/// PG 路径会在这里直接 panic（fail-fast），而不是让占位符与绑定值静默错位。
+fn pg_param_type(column: video::Column) -> &'static str {
+    use video::Column;
+    match column {
+        Column::Id | Column::CollectionId | Column::FavoriteId | Column::WatchLaterId | Column::SubmissionId => "int",
+        Column::UpperId => "bigint",
+        Column::UpperName | Column::UpperFace => "text",
+        Column::Staff => "json", // 与迁移中 json_null 定义的列类型保持一致
+        Column::Name | Column::Bvid | Column::Intro | Column::Cover => "text",
+        Column::Ctime | Column::Pubtime | Column::Favtime => "timestamp",
+        Column::DownloadStatus => "bigint",
+        Column::Valid | Column::ShouldDownload => "bool",
+        Column::Tags => "jsonb",
+        Column::SinglePage => "bool",
+        _ => unreachable!("列 {} 不参与批量更新，新增列时请在此补充 PG 参数类型", column.as_str()),
+    }
 }
 
 /// 将视频标记为失效

--- a/crates/bili_sync/src/utils/status.rs
+++ b/crates/bili_sync/src/utils/status.rs
@@ -162,6 +162,21 @@ impl<const N: usize, C> From<Status<N, C>> for u32 {
     }
 }
 
+/// 数据库实体中 download_status 列以 i64 存储（PostgreSQL 的 bigint），此处提供直连转换，
+/// 避免调用点散落 `as u32` / `as i64` 强转。状态位域的有效值域为 [0, 2^32)，
+/// 超出部分（正常情况下不存在）按 `as u32` 截断，与既有强转行为保持一致。
+impl<const N: usize, C> From<i64> for Status<N, C> {
+    fn from(status: i64) -> Self {
+        Status(status as u32, PhantomData)
+    }
+}
+
+impl<const N: usize, C> From<Status<N, C>> for i64 {
+    fn from(status: Status<N, C>) -> Self {
+        status.0 as i64
+    }
+}
+
 impl<const N: usize, C> From<Status<N, C>> for [u32; N] {
     fn from(status: Status<N, C>) -> Self {
         let mut result = [0; N];

--- a/crates/bili_sync/src/utils/time.rs
+++ b/crates/bili_sync/src/utils/time.rs
@@ -1,0 +1,43 @@
+use chrono::{Days, Local, LocalResult, NaiveDateTime, TimeZone};
+
+/// 将服务器本地墙钟时间换算为 UTC，与 SQLite 侧 `datetime(?, 'localtime')` 的语义对齐。
+/// `upper` 表示换算结果将用作比较上界（lt/lte）：夏令时回拨产生的歧义时刻取较晚的
+/// UTC 瞬间，使上界覆盖两种解释，与 SQLite 逐行转换的比较结果一致；用作下界（gte）
+/// 时取较早瞬间，同理保证覆盖。不存在的本地时刻（春季拨快）按原值降级，视为 UTC。
+///
+/// 与 SQLite 的差异：SQLite 按查询时刻的当前偏移换算所有行，本函数按目标日期的历史
+/// 偏移换算，DST 过渡窗口（每年约各一天）内两后端的比较边界可能相差至多 1 小时，
+/// 本实现按日历日语义更精确。
+pub fn local_to_utc(local: NaiveDateTime, upper: bool) -> NaiveDateTime {
+    match Local.from_local_datetime(&local) {
+        LocalResult::Single(dt) => dt.naive_utc(),
+        LocalResult::Ambiguous(earlier, later) => {
+            if upper {
+                later.naive_utc()
+            } else {
+                earlier.naive_utc()
+            }
+        }
+        LocalResult::None => local,
+    }
+}
+
+/// 计算最近 7 个本地自然日的 UTC 起止边界，与 SQLite 侧
+/// `DATE('now', '-' || n || ' days', 'localtime')` 的语义对齐。
+/// 返回 (日期字符串, 起始 UTC, 结束 UTC)，按日期升序（最旧在前）。
+pub fn last_seven_local_days() -> Vec<(String, NaiveDateTime, NaiveDateTime)> {
+    let today = Local::now().date_naive();
+    (0..7)
+        .rev()
+        .map(|n| {
+            let day = today - Days::new(n);
+            let next = day + Days::new(1);
+            (
+                day.format("%Y-%m-%d").to_string(),
+                // 起始为下界取较早解释，结束为上界取较晚解释，均保证覆盖
+                local_to_utc(day.and_hms_opt(0, 0, 0).expect("本地日期必然有效"), false),
+                local_to_utc(next.and_hms_opt(0, 0, 0).expect("本地日期必然有效"), true),
+            )
+        })
+        .collect()
+}

--- a/crates/bili_sync/src/workflow.rs
+++ b/crates/bili_sync/src/workflow.rs
@@ -372,7 +372,7 @@ pub async fn download_video_pages(
     }
     let mut video_active_model: video::ActiveModel = video_model.into();
     video_active_model.tags.reset();
-    video_active_model.download_status = Set(status.into());
+    video_active_model.download_status = Set(i64::from(status));
     video_active_model.path = Set(base_path.to_string_lossy().to_string());
     Ok(video_active_model)
 }
@@ -510,15 +510,15 @@ pub async fn download_page(
     };
     let dimension = match (page_model.width, page_model.height) {
         (Some(width), Some(height)) => Some(Dimension {
-            width,
-            height,
+            width: width as u32,
+            height: height as u32,
             rotate: 0,
         }),
         _ => None,
     };
     let page_info = PageInfo {
         cid: page_model.cid,
-        duration: page_model.duration,
+        duration: page_model.duration as u32,
         dimension,
         ..Default::default()
     };
@@ -594,7 +594,7 @@ pub async fn download_page(
         }
     }
     let mut page_active_model: page::ActiveModel = page_model.into();
-    page_active_model.download_status = Set(status.into());
+    page_active_model.download_status = Set(i64::from(status));
     page_active_model.path = Set(Some(video_path.to_string_lossy().to_string()));
     Ok(page_active_model)
 }

--- a/crates/bili_sync_entity/src/entities/collection.rs
+++ b/crates/bili_sync_entity/src/entities/collection.rs
@@ -14,7 +14,7 @@ pub struct Model {
     pub name: String,
     pub r#type: i32,
     pub path: String,
-    pub created_at: String,
+    pub created_at: DateTime,
     pub latest_row_at: DateTime,
     pub rule: Option<Rule>,
     pub filter_option: Option<Json>,

--- a/crates/bili_sync_entity/src/entities/config.rs
+++ b/crates/bili_sync_entity/src/entities/config.rs
@@ -8,7 +8,7 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,
     pub data: String,
-    pub created_at: String,
+    pub created_at: DateTime,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/bili_sync_entity/src/entities/favorite.rs
+++ b/crates/bili_sync_entity/src/entities/favorite.rs
@@ -13,7 +13,7 @@ pub struct Model {
     pub f_id: i64,
     pub name: String,
     pub path: String,
-    pub created_at: String,
+    pub created_at: DateTime,
     pub latest_row_at: DateTime,
     pub rule: Option<Rule>,
     pub filter_option: Option<Json>,

--- a/crates/bili_sync_entity/src/entities/page.rs
+++ b/crates/bili_sync_entity/src/entities/page.rs
@@ -11,13 +11,13 @@ pub struct Model {
     pub cid: i64,
     pub pid: i32,
     pub name: String,
-    pub width: Option<u32>,
-    pub height: Option<u32>,
-    pub duration: u32,
+    pub width: Option<i32>,
+    pub height: Option<i32>,
+    pub duration: i32,
     pub path: Option<String>,
     pub image: Option<String>,
-    pub download_status: u32,
-    pub created_at: String,
+    pub download_status: i64,
+    pub created_at: DateTime,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/bili_sync_entity/src/entities/submission.rs
+++ b/crates/bili_sync_entity/src/entities/submission.rs
@@ -12,7 +12,7 @@ pub struct Model {
     pub upper_id: i64,
     pub upper_name: String,
     pub path: String,
-    pub created_at: String,
+    pub created_at: DateTime,
     pub use_dynamic_api: bool,
     pub latest_row_at: DateTime,
     pub rule: Option<Rule>,

--- a/crates/bili_sync_entity/src/entities/video.rs
+++ b/crates/bili_sync_entity/src/entities/video.rs
@@ -28,12 +28,12 @@ pub struct Model {
     pub ctime: DateTime,
     pub pubtime: DateTime,
     pub favtime: DateTime,
-    pub download_status: u32,
+    pub download_status: i64,
     pub valid: bool,
     pub should_download: bool,
     pub tags: Option<StringVec>,
     pub single_page: Option<bool>,
-    pub created_at: String,
+    pub created_at: DateTime,
 }
 
 impl Model {

--- a/crates/bili_sync_entity/src/entities/watch_later.rs
+++ b/crates/bili_sync_entity/src/entities/watch_later.rs
@@ -10,7 +10,7 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i32,
     pub path: String,
-    pub created_at: String,
+    pub created_at: DateTime,
     pub latest_row_at: DateTime,
     pub rule: Option<Rule>,
     pub filter_option: Option<Json>,

--- a/crates/bili_sync_migration/src/lib.rs
+++ b/crates/bili_sync_migration/src/lib.rs
@@ -1,4 +1,16 @@
 pub use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::DatabaseBackend;
+
+/// created_at 的数据库默认值：SQLite 的 CURRENT_TIMESTAMP 返回 UTC 文本；
+/// PostgreSQL 上 CURRENT_TIMESTAMP 是 timestamptz，写入 timestamp 列时按会话
+/// 时区转墙钟，需显式换算出 UTC 以保证两后端存储语义一致
+pub fn utc_now_default(manager: &SchemaManager) -> SimpleExpr {
+    if manager.get_database_backend() == DatabaseBackend::Postgres {
+        Expr::cust("(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::timestamp")
+    } else {
+        Expr::current_timestamp().into()
+    }
+}
 
 mod m20240322_000001_create_table;
 mod m20240505_130850_add_collection;

--- a/crates/bili_sync_migration/src/m20240322_000001_create_table.rs
+++ b/crates/bili_sync_migration/src/m20240322_000001_create_table.rs
@@ -1,5 +1,7 @@
 use sea_orm_migration::prelude::*;
 
+use crate::utc_now_default;
+
 #[derive(DeriveMigrationName)]
 pub struct Migration;
 
@@ -13,18 +15,18 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(Favorite::Id)
-                            .unsigned()
+                            .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Favorite::FId).unique_key().unsigned().not_null())
+                    .col(ColumnDef::new(Favorite::FId).unique_key().big_unsigned().not_null())
                     .col(ColumnDef::new(Favorite::Name).string().not_null())
                     .col(ColumnDef::new(Favorite::Path).string().not_null())
                     .col(
                         ColumnDef::new(Favorite::CreatedAt)
                             .timestamp()
-                            .default(Expr::current_timestamp())
+                            .default(utc_now_default(manager))
                             .not_null(),
                     )
                     .to_owned(),
@@ -37,32 +39,32 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(Video::Id)
-                            .unsigned()
+                            .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Video::FavoriteId).unsigned().not_null())
-                    .col(ColumnDef::new(Video::UpperId).unsigned().not_null())
+                    .col(ColumnDef::new(Video::FavoriteId).integer().not_null())
+                    .col(ColumnDef::new(Video::UpperId).big_unsigned().not_null())
                     .col(ColumnDef::new(Video::UpperName).string().not_null())
                     .col(ColumnDef::new(Video::UpperFace).string().not_null())
                     .col(ColumnDef::new(Video::Name).string().not_null())
                     .col(ColumnDef::new(Video::Path).string().not_null())
-                    .col(ColumnDef::new(Video::Category).small_unsigned().not_null())
+                    .col(ColumnDef::new(Video::Category).integer().not_null())
                     .col(ColumnDef::new(Video::Bvid).string().not_null())
                     .col(ColumnDef::new(Video::Intro).string().not_null())
                     .col(ColumnDef::new(Video::Cover).string().not_null())
                     .col(ColumnDef::new(Video::Ctime).timestamp().not_null())
                     .col(ColumnDef::new(Video::Pubtime).timestamp().not_null())
                     .col(ColumnDef::new(Video::Favtime).timestamp().not_null())
-                    .col(ColumnDef::new(Video::DownloadStatus).unsigned().not_null())
+                    .col(ColumnDef::new(Video::DownloadStatus).big_unsigned().not_null())
                     .col(ColumnDef::new(Video::Valid).boolean().not_null())
                     .col(ColumnDef::new(Video::Tags).json_binary())
                     .col(ColumnDef::new(Video::SinglePage).boolean())
                     .col(
                         ColumnDef::new(Video::CreatedAt)
                             .timestamp()
-                            .default(Expr::current_timestamp())
+                            .default(utc_now_default(manager))
                             .not_null(),
                     )
                     .to_owned(),
@@ -75,25 +77,25 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(Page::Id)
-                            .unsigned()
+                            .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Page::VideoId).unsigned().not_null())
-                    .col(ColumnDef::new(Page::Cid).unsigned().not_null())
-                    .col(ColumnDef::new(Page::Pid).unsigned().not_null())
+                    .col(ColumnDef::new(Page::VideoId).integer().not_null())
+                    .col(ColumnDef::new(Page::Cid).big_unsigned().not_null())
+                    .col(ColumnDef::new(Page::Pid).integer().not_null())
                     .col(ColumnDef::new(Page::Name).string().not_null())
-                    .col(ColumnDef::new(Page::Width).unsigned())
-                    .col(ColumnDef::new(Page::Height).unsigned())
-                    .col(ColumnDef::new(Page::Duration).unsigned().not_null())
+                    .col(ColumnDef::new(Page::Width).integer())
+                    .col(ColumnDef::new(Page::Height).integer())
+                    .col(ColumnDef::new(Page::Duration).integer().not_null())
                     .col(ColumnDef::new(Page::Path).string())
                     .col(ColumnDef::new(Page::Image).string())
-                    .col(ColumnDef::new(Page::DownloadStatus).unsigned().not_null())
+                    .col(ColumnDef::new(Page::DownloadStatus).big_unsigned().not_null())
                     .col(
                         ColumnDef::new(Page::CreatedAt)
                             .timestamp()
-                            .default(Expr::current_timestamp())
+                            .default(utc_now_default(manager))
                             .not_null(),
                     )
                     .to_owned(),

--- a/crates/bili_sync_migration/src/m20240505_130850_add_collection.rs
+++ b/crates/bili_sync_migration/src/m20240505_130850_add_collection.rs
@@ -1,4 +1,7 @@
 use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::DatabaseBackend;
+
+use crate::utc_now_default;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -14,20 +17,20 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(Collection::Id)
-                            .unsigned()
+                            .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Collection::SId).unsigned().not_null())
-                    .col(ColumnDef::new(Collection::MId).unsigned().not_null())
+                    .col(ColumnDef::new(Collection::SId).big_unsigned().not_null())
+                    .col(ColumnDef::new(Collection::MId).big_unsigned().not_null())
                     .col(ColumnDef::new(Collection::Name).string().not_null())
-                    .col(ColumnDef::new(Collection::Type).small_unsigned().not_null())
+                    .col(ColumnDef::new(Collection::Type).unsigned().not_null())
                     .col(ColumnDef::new(Collection::Path).string().not_null())
                     .col(
                         ColumnDef::new(Collection::CreatedAt)
                             .timestamp()
-                            .default(Expr::current_timestamp())
+                            .default(utc_now_default(manager))
                             .not_null(),
                     )
                     .to_owned(),
@@ -87,9 +90,18 @@ impl MigrationTrait for Migration {
                     .to_owned(),
             )
             .await?;
-        // 在唯一索引中，NULL 不等于 NULL，所以需要使用 ifnull 函数排除空的情况
-        db.execute_unprepared("CREATE UNIQUE INDEX `idx_video_cid_fid_bvid` ON `video` (ifnull(`collection_id`, -1), ifnull(`favorite_id`, -1), `bvid`)")
-            .await?;
+        // 在唯一索引中，NULL 不等于 NULL，所以需要使用 ifnull/COALESCE 函数排除空的情况
+        match manager.get_database_backend() {
+            DatabaseBackend::Sqlite => {
+                db.execute_unprepared("CREATE UNIQUE INDEX `idx_video_cid_fid_bvid` ON `video` (ifnull(`collection_id`, -1), ifnull(`favorite_id`, -1), `bvid`)")
+                    .await?;
+            }
+            DatabaseBackend::Postgres => {
+                db.execute_unprepared("CREATE UNIQUE INDEX idx_video_cid_fid_bvid ON video (COALESCE(collection_id, -1), COALESCE(favorite_id, -1), bvid)")
+                    .await?;
+            }
+            _ => unreachable!(),
+        }
         Ok(())
     }
 

--- a/crates/bili_sync_migration/src/m20240709_130914_watch_later.rs
+++ b/crates/bili_sync_migration/src/m20240709_130914_watch_later.rs
@@ -1,4 +1,7 @@
 use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::DatabaseBackend;
+
+use crate::utc_now_default;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -14,7 +17,7 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(WatchLater::Id)
-                            .unsigned()
+                            .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
@@ -23,7 +26,7 @@ impl MigrationTrait for Migration {
                     .col(
                         ColumnDef::new(WatchLater::CreatedAt)
                             .timestamp()
-                            .default(Expr::current_timestamp())
+                            .default(utc_now_default(manager))
                             .not_null(),
                     )
                     .to_owned(),
@@ -45,8 +48,17 @@ impl MigrationTrait for Migration {
                     .to_owned(),
             )
             .await?;
-        db.execute_unprepared("CREATE UNIQUE INDEX `idx_video_unique` ON `video` (ifnull(`collection_id`, -1), ifnull(`favorite_id`, -1), ifnull(`watch_later_id`, -1), `bvid`)")
-            .await?;
+        match manager.get_database_backend() {
+            DatabaseBackend::Sqlite => {
+                db.execute_unprepared("CREATE UNIQUE INDEX `idx_video_unique` ON `video` (ifnull(`collection_id`, -1), ifnull(`favorite_id`, -1), ifnull(`watch_later_id`, -1), `bvid`)")
+                    .await?;
+            }
+            DatabaseBackend::Postgres => {
+                db.execute_unprepared("CREATE UNIQUE INDEX idx_video_unique ON video (COALESCE(collection_id, -1), COALESCE(favorite_id, -1), COALESCE(watch_later_id, -1), bvid)")
+                    .await?;
+            }
+            _ => unreachable!(),
+        }
         Ok(())
     }
 
@@ -65,8 +77,17 @@ impl MigrationTrait for Migration {
                     .to_owned(),
             )
             .await?;
-        db.execute_unprepared("CREATE UNIQUE INDEX `idx_video_cid_fid_bvid` ON `video` (ifnull(`collection_id`, -1), ifnull(`favorite_id`, -1), `bvid`)")
-            .await?;
+        match manager.get_database_backend() {
+            DatabaseBackend::Sqlite => {
+                db.execute_unprepared("CREATE UNIQUE INDEX `idx_video_cid_fid_bvid` ON `video` (ifnull(`collection_id`, -1), ifnull(`favorite_id`, -1), `bvid`)")
+                    .await?;
+            }
+            DatabaseBackend::Postgres => {
+                db.execute_unprepared("CREATE UNIQUE INDEX idx_video_cid_fid_bvid ON video (COALESCE(collection_id, -1), COALESCE(favorite_id, -1), bvid)")
+                    .await?;
+            }
+            _ => unreachable!(),
+        }
         manager
             .drop_table(Table::drop().table(WatchLater::Table).to_owned())
             .await

--- a/crates/bili_sync_migration/src/m20240724_161008_submission.rs
+++ b/crates/bili_sync_migration/src/m20240724_161008_submission.rs
@@ -1,4 +1,7 @@
 use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::DatabaseBackend;
+
+use crate::utc_now_default;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -14,18 +17,23 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(
                         ColumnDef::new(Submission::Id)
-                            .unsigned()
+                            .integer()
                             .not_null()
                             .auto_increment()
                             .primary_key(),
                     )
-                    .col(ColumnDef::new(Submission::UpperId).unique_key().unsigned().not_null())
+                    .col(
+                        ColumnDef::new(Submission::UpperId)
+                            .unique_key()
+                            .big_unsigned()
+                            .not_null(),
+                    )
                     .col(ColumnDef::new(Submission::UpperName).string().not_null())
                     .col(ColumnDef::new(Submission::Path).string().not_null())
                     .col(
                         ColumnDef::new(Submission::CreatedAt)
                             .timestamp()
-                            .default(Expr::current_timestamp())
+                            .default(utc_now_default(manager))
                             .not_null(),
                     )
                     .to_owned(),
@@ -42,8 +50,17 @@ impl MigrationTrait for Migration {
                     .to_owned(),
             )
             .await?;
-        db.execute_unprepared("CREATE UNIQUE INDEX `idx_video_unique` ON `video` (ifnull(`collection_id`, -1), ifnull(`favorite_id`, -1), ifnull(`watch_later_id`, -1), ifnull(`submission_id`, -1), `bvid`)")
-            .await?;
+        match manager.get_database_backend() {
+            DatabaseBackend::Sqlite => {
+                db.execute_unprepared("CREATE UNIQUE INDEX `idx_video_unique` ON `video` (ifnull(`collection_id`, -1), ifnull(`favorite_id`, -1), ifnull(`watch_later_id`, -1), ifnull(`submission_id`, -1), `bvid`)")
+                    .await?;
+            }
+            DatabaseBackend::Postgres => {
+                db.execute_unprepared("CREATE UNIQUE INDEX idx_video_unique ON video (COALESCE(collection_id, -1), COALESCE(favorite_id, -1), COALESCE(watch_later_id, -1), COALESCE(submission_id, -1), bvid)")
+                    .await?;
+            }
+            _ => unreachable!(),
+        }
         Ok(())
     }
 
@@ -62,8 +79,17 @@ impl MigrationTrait for Migration {
                     .to_owned(),
             )
             .await?;
-        db.execute_unprepared("CREATE UNIQUE INDEX `idx_video_unique` ON `video` (ifnull(`collection_id`, -1), ifnull(`favorite_id`, -1), ifnull(`watch_later_id`, -1), `bvid`)")
-            .await?;
+        match manager.get_database_backend() {
+            DatabaseBackend::Sqlite => {
+                db.execute_unprepared("CREATE UNIQUE INDEX `idx_video_unique` ON `video` (ifnull(`collection_id`, -1), ifnull(`favorite_id`, -1), ifnull(`watch_later_id`, -1), `bvid`)")
+                    .await?;
+            }
+            DatabaseBackend::Postgres => {
+                db.execute_unprepared("CREATE UNIQUE INDEX idx_video_unique ON video (COALESCE(collection_id, -1), COALESCE(favorite_id, -1), COALESCE(watch_later_id, -1), bvid)")
+                    .await?;
+            }
+            _ => unreachable!(),
+        }
         manager
             .drop_table(Table::drop().table(Submission::Table).to_owned())
             .await

--- a/crates/bili_sync_migration/src/m20250122_062926_add_latest_row_at.rs
+++ b/crates/bili_sync_migration/src/m20250122_062926_add_latest_row_at.rs
@@ -1,5 +1,6 @@
 use sea_orm_migration::prelude::*;
 use sea_orm_migration::schema::*;
+use sea_orm_migration::sea_orm::DatabaseBackend;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -41,22 +42,28 @@ impl MigrationTrait for Migration {
             )
             .await?;
         // 手动写 SQL 更新这四张表的 latest 字段到当前取值
+        // IFNULL 为 SQLite 专用函数，PostgreSQL 使用等价的 COALESCE
         let db = manager.get_connection();
-        db.execute_unprepared(
-            "UPDATE favorite SET latest_row_at = (SELECT IFNULL(MAX(favtime), '1970-01-01 00:00:00') FROM video WHERE favorite_id = favorite.id)",
-        )
+        let null_func = match manager.get_database_backend() {
+            DatabaseBackend::Sqlite => "IFNULL",
+            DatabaseBackend::Postgres => "COALESCE",
+            _ => unreachable!(),
+        };
+        db.execute_unprepared(&format!(
+            "UPDATE favorite SET latest_row_at = (SELECT {null_func}(MAX(favtime), '1970-01-01 00:00:00') FROM video WHERE favorite_id = favorite.id)",
+        ))
         .await?;
-        db.execute_unprepared(
-            "UPDATE collection SET latest_row_at = (SELECT IFNULL(MAX(pubtime), '1970-01-01 00:00:00') FROM video WHERE collection_id = collection.id)",
-        )
+        db.execute_unprepared(&format!(
+            "UPDATE collection SET latest_row_at = (SELECT {null_func}(MAX(pubtime), '1970-01-01 00:00:00') FROM video WHERE collection_id = collection.id)",
+        ))
         .await?;
-        db.execute_unprepared(
-            "UPDATE watch_later SET latest_row_at = (SELECT IFNULL(MAX(favtime), '1970-01-01 00:00:00') FROM video WHERE watch_later_id = watch_later.id)",
-        )
+        db.execute_unprepared(&format!(
+            "UPDATE watch_later SET latest_row_at = (SELECT {null_func}(MAX(favtime), '1970-01-01 00:00:00') FROM video WHERE watch_later_id = watch_later.id)",
+        ))
         .await?;
-        db.execute_unprepared(
-            "UPDATE submission SET latest_row_at = (SELECT IFNULL(MAX(ctime), '1970-01-01 00:00:00') FROM video WHERE submission_id = submission.id)",
-        )
+        db.execute_unprepared(&format!(
+            "UPDATE submission SET latest_row_at = (SELECT {null_func}(MAX(ctime), '1970-01-01 00:00:00') FROM video WHERE submission_id = submission.id)",
+        ))
         .await?;
         Ok(())
     }

--- a/crates/bili_sync_migration/src/m20250613_043257_add_config.rs
+++ b/crates/bili_sync_migration/src/m20250613_043257_add_config.rs
@@ -1,5 +1,7 @@
 use sea_orm_migration::prelude::*;
 
+use crate::utc_now_default;
+
 #[derive(DeriveMigrationName)]
 pub struct Migration;
 
@@ -22,7 +24,7 @@ impl MigrationTrait for Migration {
                     .col(
                         ColumnDef::new(Config::CreatedAt)
                             .timestamp()
-                            .default(Expr::current_timestamp())
+                            .default(utc_now_default(manager))
                             .not_null(),
                     )
                     .to_owned(),

--- a/crates/bili_sync_migration/src/m20250903_094454_add_rule_and_should_download.rs
+++ b/crates/bili_sync_migration/src/m20250903_094454_add_rule_and_should_download.rs
@@ -19,7 +19,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 Table::alter()
                     .table(WatchLater::Table)
-                    .add_column(text_null(WatchLater::Rule))
+                    .add_column(json_null(WatchLater::Rule))
                     .to_owned(),
             )
             .await?;
@@ -27,7 +27,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 Table::alter()
                     .table(Submission::Table)
-                    .add_column(text_null(Submission::Rule))
+                    .add_column(json_null(Submission::Rule))
                     .to_owned(),
             )
             .await?;
@@ -35,7 +35,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 Table::alter()
                     .table(Favorite::Table)
-                    .add_column(text_null(Favorite::Rule))
+                    .add_column(json_null(Favorite::Rule))
                     .to_owned(),
             )
             .await?;
@@ -43,7 +43,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 Table::alter()
                     .table(Collection::Table)
-                    .add_column(text_null(Collection::Rule))
+                    .add_column(json_null(Collection::Rule))
                     .to_owned(),
             )
             .await

--- a/crates/bili_sync_migration/src/m20260324_055217_add_staff.rs
+++ b/crates/bili_sync_migration/src/m20260324_055217_add_staff.rs
@@ -10,7 +10,7 @@ impl MigrationTrait for Migration {
             .alter_table(
                 Table::alter()
                     .table(Video::Table)
-                    .add_column(text_null(Video::Staff))
+                    .add_column(json_null(Video::Staff))
                     .to_owned(),
             )
             .await

--- a/crates/bili_sync_migration/src/m20260821_025000_mark_empty_tags_for_refetch.rs
+++ b/crates/bili_sync_migration/src/m20260821_025000_mark_empty_tags_for_refetch.rs
@@ -1,4 +1,5 @@
 use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::DatabaseBackend;
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
@@ -6,10 +7,22 @@ pub struct Migration;
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        manager
-            .get_connection()
-            .execute_unprepared("UPDATE video SET tags = NULL WHERE tags = '[]'")
-            .await?;
+        // PostgreSQL 的 jsonb 列比较需要显式类型转换
+        match manager.get_database_backend() {
+            DatabaseBackend::Sqlite => {
+                manager
+                    .get_connection()
+                    .execute_unprepared("UPDATE video SET tags = NULL WHERE tags = '[]'")
+                    .await?;
+            }
+            DatabaseBackend::Postgres => {
+                manager
+                    .get_connection()
+                    .execute_unprepared("UPDATE video SET tags = NULL WHERE tags = '[]'::jsonb")
+                    .await?;
+            }
+            _ => unreachable!(),
+        }
         Ok(())
     }
 

--- a/scripts/db-migrate/README.md
+++ b/scripts/db-migrate/README.md
@@ -1,0 +1,116 @@
+# db-migrate — SQLite→PostgreSQL 迁移实测验证工具链
+
+面向维护者的迁移验证工具链，用于实测并评估 SQLite→PG 数据迁移的保真度。
+本目录脚本全部**动态推导**（表清单/列类型/cast 规则从数据库 catalog 获取，不手写），
+维护者给实体加列/加表后重跑即可，无需修改任何"迁移配置清单"。
+
+## 背景结论（2026-08-27 实测）
+
+- **schema 路线**：目标 PG 库的 schema 由 bili-sync 自己的 sea-orm 迁移生成（启动一次即全量建好），
+  迁移工具只做 data-only 导入。`seaql_migrations` 不随迁。
+- **pgloader 3.6.10 实测结论**：
+  - 无损：行数、位域 bigint（含 ≥2³¹）、时间戳（SQLite 文本 → timestamp，微秒精度）、
+    JSON（`json_text→json`、`jsonb_text→jsonb`）、布尔（0/1→boolean）、config（TEXT 字节级）、
+    唯一索引（目标库迁移自建，COALESCE 版本生效）
+  - **行级错误不影响退出码**：坏数据（如无法解析的时间戳）导致整表 COPY 失败时
+    仍 `exit 0`，只有 summary 的 errors 列有计数；`migrate.sh` C5 的行数对账为此兜底
+  - **序列**：`reset sequences` 对非空表已对齐（last_value=MAX(id)、is_called=true），
+    但会把空表重置成 last_value=1、is_called=true（下一个分配值跳 1 号）；
+    `migrate.sh` C4b 统一按 MAX(id) 幂等重设（含空表），无需人工 setval
+- **DDL 对比注意**：对比基准需用当前代码新建的库（如 bili_sync_tz）。
+  旧库（bili_sync）的 `created_at DEFAULT CURRENT_TIMESTAMP` 是 9864e3c 修复前的历史遗留，
+  SeaORM 迁移不修改既有列默认值，与迁移工具无关。
+
+## 脚本清单
+
+| 脚本 | 职责 | 推导点 |
+|---|---|---|
+| `inject-credential.sh <PGURL> <SQLITE_DB> [工作目录]` | PG config 整行注入 SQLite config 表（凭证制备，默认 `mktemp -d` 退出自动清理） | config 表 id=1 约定 |
+| `snapshot-baseline.sh <SQLITE_DB> <输出目录>` | SQLite 形态基线导出（行数/schema/位域/时间戳/JSON/NULL/布尔/md5） | 遍历 sqlite_master |
+| `gen-migrate-conf.sh <PGURL> <SQLITE_DB> <输出>` | 动态生成 pgloader .load（表清单 + cast 规则） | pg_tables + information_schema |
+| `migrate.sh <PGURL> <SQLITE_DB> <BIN> [--config-dir <dir>] [--force] [--create-db]` | 校验/准备目标库 → bili-sync 建 schema → TRUNCATE → 导入 → 序列对齐 + 行数对账 | 同上 |
+| `reconcile.sh <SQLITE_DB> <PGURL> [基线目录]` | 对账：行数/位域/时间戳/JSON/布尔/config md5/UNIQUE/序列 | 两库 catalog 遍历 |
+| `compare-ddl.sh <PGURL> <库A> <库B>` | pg_dump schema 对比（自动剔除 tz_probe 类残留表） | pg_dump 全量 |
+| `compare-data.sh <PGURL> <源库A> <迁移库B> <SQLITE_DB>` | 数据格式五维对比 + config 凭证三方 md5 | information_schema |
+
+## PGURL 连接参数（TLS 等）
+
+- PGURL 为**完整连接串**（含库名与可选 query 参数，各工具的自然用法），库名由 `split_pgurl`
+  从连接串提取（缺库名显式报错）；多库对比类脚本（compare-ddl/compare-data）仍以
+  「服务器级 URL + 库名参数」调用。切分逻辑集中在公共库 `lib-pgurl.sh`
+  （各脚本 source，不解析不转义）。连接串按 URL 规则解析：密码等含特殊字符
+  （`/`、`?`、`@`、`%` 等）时必须 percent-encode（如 `/` → `%2F`），
+  与 libpq 及各工具的要求一致
+- **密码传递（2026-09-03 安全加固）**：连接串里的密码会从 psql/pg_dump 的 argv 中移除
+  （argv 会被 `ps` 全程可见），改经 `PGPASSWORD` 环境变量传递（libpq 的 URL 密码优先级
+  高于 PGPASSWORD，故必须同时移除 URL 密码段；percent-encode 的密码由 `lib-pgurl.sh`
+  自动解码）。**唯一例外**：`migrate.sh` 启动 bili-sync 建 schema 时仍传完整 URL——
+  sqlx 不读 PGPASSWORD，且该进程短暂存在。`gen-migrate-conf.sh` 生成的 `.load` 的
+  INTO 串含密码（pgloader 从文件读取、不经 argv），生成后自动 `chmod 600`
+- query 参数可写多个（如 `?sslmode=require&connect_timeout=15`）。**psql（libpq）与
+  bili-sync（sqlx）直接消费 URL 参数**：sqlx 支持 sslmode（含 verify-full）/sslrootcert/
+  sslcert/sslkey/application_name/options，未知参数（如 connect_timeout）忽略并告警；
+  URL 参数优先级高于环境变量（libpq 标准），两处同传无冲突
+- **pgloader 例外**（2026-08-29 源码核对 + TLS 沙箱实测，3.6.10）：它用 postmodern+CL+SSL
+  连 PG，**不走 libpq**。`.load` 的 INTO 串不带 query（其 URI 参数白名单只有
+  sslmode/host/port/dbname/user/password/tablename，且 uri-param 类参数作末参数会把
+  `.load` 后续内容整个吞进参数值），`migrate.sh` 把 sslmode 导出为 `PGSSLMODE` 环境变量
+  传递。环境变量中 pgloader **只读 PGSSLMODE**，值仅认 disable/allow/prefer/require——
+  `verify-full`/`verify-ca` 会让它解析 .load 时直接崩溃（`migrate.sh` 提前报错拦截）；
+  `PGSSLROOTCERT`/`PGSSLCERT`/`PGSSLKEY`/`PGCONNECT_TIMEOUT`/`PGAPPNAME`/`PGOPTIONS`
+  一概不读（客户端证书只认硬编码 `~/.postgresql/postgresql.crt`，`migrate.sh` 对这些
+  参数会发警告）
+- **pgloader 的 require 与 libpq 的 require 语义不同**：pgloader 会按**系统 CA 信任库**验证
+  服务器证书（libpq 的 require 只加密不验证）。目标服务器用内部 CA 时，把 CA 装入运行
+  pgloader 机器的系统信任库（Debian/Ubuntu：`update-ca-certificates`）后用
+  `sslmode=require` 即可全链路 TLS（pgloader 不做主机名校验）。什么 TLS 参数都不配时
+  pgloader 默认**明文**连接（其 use-ssl 默认 `:no`，服务器同时接受明文时会静默降级）——
+  `migrate.sh` 会在服务器开着 TLS 而未配 sslmode 时发出警告
+
+## 常用流程（维护者改数据库后回归）
+
+```bash
+# 1. 冻结迁移源（先停 bili-sync）并导出基线
+sqlite3 data.sqlite 'PRAGMA wal_checkpoint(TRUNCATE);'
+snapshot-baseline.sh data.sqlite baseline/
+
+# 2. 全新迁移（校验/建库→建 schema→清默认行→动态配置→pgloader 导入→序列对齐+行数对账）
+#    脚本不 DROP 数据库、也不自动建库：目标库需为空（无表），或加 --force 清空库内表后重跑；
+#    目标库不存在时加 --create-db 自动创建空库（需 CREATEDB 权限）
+migrate.sh "$PGURL" data.sqlite /path/to/bili-sync-rs --force   # PGURL 含库名，如 .../bili_migrate_test?sslmode=require
+
+# 3. 对账（对照基线；序列已由 migrate.sh C4b 自动对齐，此处为复核）
+reconcile.sh data.sqlite "$PGURL" baseline/   # PGURL 含库名
+
+# 4. 与现有库对比（DDL 用 bili_sync_tz 等全新库做基准；数据格式与 bili_sync 对比）
+compare-ddl.sh "$PGURL" bili_sync_tz bili_migrate_test
+compare-data.sh "$PGURL" bili_sync bili_migrate_test data.sqlite
+```
+
+## 序列对齐
+
+已由 `migrate.sh` C4b 自动完成：对全部业务表按 `MAX(id)` 幂等重设
+（非空表 `setval(seq, MAX(id), true)`、空表 `setval(seq, 1, false)`），
+`reconcile.sh` 8/8 仍会逐表复核「下一个分配值 == MAX(id)+1」。
+
+## 唯一需人工维护的点
+
+`gen-migrate-conf.sh` 顶部的 `SEAQ_ORM_TYPE_MAP`（sea-query 的确定性类型映射，
+PG data_type → SQLite 声明类型名，当前 10 条：timestamp/json/jsonb/boolean/bigint/integer/smallint/text/varchar/char）。
+仅当 sea-query 支持新的列类型映射时才需更新——集中一处，不会散落多处配置漏改。
+
+## 凭证安全约定
+
+- 密码经 `PGPASSWORD` 环境变量传递，不进入 psql/pg_dump 的命令行参数（`ps` 不可见）；
+  bili-sync 建 schema 一腿除外（sqlx 不读 PGPASSWORD，进程短暂存在）。
+- 凭证明文只落工作目录：`inject-credential.sh` 不传工作目录时用 `mktemp -d`（0700，
+  仅当前用户可读），退出自动清理；传入工作目录时由用户管理，脚本异常退出会提示清理。
+- `gen-migrate-conf.sh` 生成的 `.load` 含密码，自动 `chmod 600`。
+- 终端只输出 md5 与存在性矩阵（布尔/长度），不打印凭证值。
+
+## 环境
+
+- 本机无 cargo，全部命令在 podman 容器（bili-dev）内执行；PG 目标库在 bili-pg 容器
+  （pasta 网络下容器内连 host 服务需用 host 真实 IP：`PGURL=postgres://postgres:bili@10.1.2.1:5433/bili_migrate_test`，
+  `host.containers.internal` 与容器内 `127.0.0.1` 均不通，2026-08-29 实测）。
+- 依赖：psql / sqlite3 / jq / pgloader / pg_dump（导入工具固定为 pgloader）。

--- a/scripts/db-migrate/compare-data.sh
+++ b/scripts/db-migrate/compare-data.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# compare-data.sh — 数据格式层对比：迁移后库 vs 现有 PG 库（阶段 D2）
+#
+# 六项对比（全部动态推导，不写死列名）：
+#   1. 类型矩阵（information_schema.columns）
+#   2. NULL 分布（逐表逐可空列）
+#   3. 位域值域（download_status DISTINCT）
+#   4. 时间戳（类型与抽样）
+#   5. JSON 结构（jsonb/json 列抽样解析）
+#   6. config 凭证三方 md5（PG 源 → SQLite → 迁回 PG 的 credential 五字段）
+#
+# 注意：两库数据内容预期不同（源库是历史数据、迁移库是新扫描数据），
+# 只做格式对比；默认值差异已知来自旧库历史（CURRENT_TIMESTAMP 修复 9864e3c），不对比。
+#
+# 用法：
+#   compare-data.sh <PGURL> <源库A> <迁移库B> <SQLITE_DB>
+
+set -euo pipefail
+
+PGURL="${1:?用法: compare-data.sh <PGURL> <源库A> <迁移库B> <SQLITE_DB>}"
+DB_A="${2:?缺源库A（如 bili_sync）}"
+DB_B="${3:?缺迁移库B（如 bili_migrate_test）}"
+SQLITE_DB="${4:?缺 SQLITE_DB}"
+
+# sqlite3 连不存在路径会自动建空库文件，路径打错会把空库当作源来对比——必须先验存在且非空
+# （校验集合与下方 SRC_TABLES 一致，否则空表清单会拼出 IN () 语法错误）
+[[ -f "$SQLITE_DB" ]] || { echo "错误: SQLite 库不存在: $SQLITE_DB" >&2; exit 1; }
+[[ "$(sqlite3 "$SQLITE_DB" "SELECT count(*) FROM sqlite_master
+    WHERE type='table' AND name NOT IN ('seaql_migrations','sqlite_sequence','sqlite_stat1','sqlite_stat4');")" != "0" ]] \
+    || { echo "错误: SQLite 库无业务表（空库或路径错误）: $SQLITE_DB" >&2; exit 1; }
+# jq 缺失时 5/6 会把「工具缺失」误报成「解析失败」——显式前置检查
+command -v jq >/dev/null 2>&1 || { echo "错误: 未安装 jq（5/6 JSON 结构检查需要）" >&2; exit 1; }
+
+# 从公共库加载 PGURL 结构切分（提取库名/服务器段/query 参数）
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib-pgurl.sh"
+split_pgurl
+# 密码改经 PGPASSWORD 传递：psql 的 argv 会被 `ps` 全程可见，一律用 PGURL_NOPASS_SERVER
+strip_pg_password
+
+PASS=0; FAIL=0
+ok()  { echo "  ✓ $1"; PASS=$((PASS+1)); }
+bad() { echo "  ✗ $1"; FAIL=$((FAIL+1)); }
+
+md5() { md5sum | cut -d' ' -f1; }
+
+WORK="$(mktemp -d /tmp/data-cmp.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+# 对比范围限定为 SQLite 源的真实业务表：源库A（历史库）可能含手工测试残留表
+# （如 tz_probe），其列会假报类型矩阵差异
+SRC_TABLES=$(sqlite3 "$SQLITE_DB" "SELECT name FROM sqlite_master
+    WHERE type='table' AND name NOT IN ('seaql_migrations','sqlite_sequence','sqlite_stat1','sqlite_stat4');")
+TABLE_LIST=$(echo "$SRC_TABLES" | sed "s/^/'/;s/$/'/" | paste -sd, -)
+
+echo "=== 1/6 类型矩阵对比（表/列/类型/可空，限定 SQLite 源业务表）==="
+for db in "$DB_A" "$DB_B"; do
+    psql "$PGURL_NOPASS_SERVER/$db$PGURL_QUERY" -Atc \
+        "SELECT table_name || '.' || column_name || ' ' || data_type || ' ' || is_nullable
+         FROM information_schema.columns
+         WHERE table_schema='public' AND table_name IN ($TABLE_LIST) ORDER BY 1;" > "$WORK/cmp_$db.txt"
+done
+if diff -q "$WORK/cmp_$DB_A.txt" "$WORK/cmp_$DB_B.txt" > /dev/null; then
+    ok "类型矩阵一致（$(wc -l < "$WORK/cmp_$DB_A.txt") 列）"
+else
+    bad "类型矩阵差异:"; diff "$WORK/cmp_$DB_A.txt" "$WORK/cmp_$DB_B.txt" | head -10
+fi
+
+echo "=== 2/6 NULL 分布对比 ==="
+# 同一份数据应保真：迁移后库 vs SQLite 源的「含 NULL 列集合」必须一致；
+# 与源库A（不同历史数据）的差异属内容差异，仅作参考输出
+null_cols_pg() { # $1=库名（注意 set -e 下不能用 && 短路，条件为假会退出）
+    local db="$1"
+    for t in $(psql "$PGURL_NOPASS_SERVER/$db$PGURL_QUERY" -Atc "SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename<>'seaql_migrations'"); do
+        for c in $(psql "$PGURL_NOPASS_SERVER/$db$PGURL_QUERY" -Atc "SELECT column_name FROM information_schema.columns WHERE table_name='$t' AND is_nullable='YES' AND table_schema='public';"); do
+            n=$(psql "$PGURL_NOPASS_SERVER/$db$PGURL_QUERY" -Atc "SELECT count(*) FROM \"$t\" WHERE \"$c\" IS NULL;")
+            if [[ "$n" != "0" ]]; then echo "$t.$c"; fi
+        done
+    done | sort
+}
+null_cols_sqlite() { # SQLite 源：对每个可空列输出含 NULL 的列
+    local db="$1"
+    for t in $(sqlite3 "$db" "SELECT name FROM sqlite_master WHERE type='table' AND name NOT IN ('seaql_migrations','sqlite_sequence','sqlite_stat1','sqlite_stat4');"); do
+        for c in $(sqlite3 "$db" "PRAGMA table_info(\"$t\");" | awk -F'|' '$4=="0" && $2!="id" {print $2}'); do
+            n=$(sqlite3 "$db" "SELECT count(*) FROM \"$t\" WHERE \"$c\" IS NULL;")
+            if [[ "$n" != "0" ]]; then echo "$t.$c"; fi
+        done
+    done | sort
+}
+null_cols_pg "$DB_B" > "$WORK/null_B.txt"
+null_cols_sqlite "$SQLITE_DB" > "$WORK/null_S.txt"
+echo "-- 迁移后库含NULL列: $(tr '\n' ' ' < "$WORK/null_B.txt")"
+echo "-- SQLite 源含NULL列: $(tr '\n' ' ' < "$WORK/null_S.txt")"
+if diff -q "$WORK/null_B.txt" "$WORK/null_S.txt" > /dev/null; then
+    ok "NULL 列集合与 SQLite 源一致（同一数据保真）"
+else
+    bad "NULL 列集合与源不一致:"; diff "$WORK/null_S.txt" "$WORK/null_B.txt" | head -10
+fi
+echo "-- 参考: 源库A($DB_A) 含NULL列: $(tr '\n' ' ' < <(null_cols_pg "$DB_A"))（历史数据不同，差异属内容差异）"
+
+echo "=== 3/6 位域值域（download_status DISTINCT）==="
+for db in "$DB_A" "$DB_B"; do
+    psql "$PGURL_NOPASS_SERVER/$db$PGURL_QUERY" -Atc "SELECT DISTINCT download_status FROM video ORDER BY 1;" > "$WORK/st_$db.txt"
+    echo "-- $db: $(tr '\n' ' ' < "$WORK/st_$db.txt")"
+done
+# 格式判据：值域均落在 bigint 合法范围（不做相等比较，内容预期不同）；
+# ok 结论仅在两库均无非法值时输出，否则只报 bad、不虚增 PASS
+FAIL_BEFORE=$FAIL
+for db in "$DB_A" "$DB_B"; do
+    while read -r v; do
+        [[ "$v" =~ ^[0-9]+$ ]] || bad "$db 位域含非法值: $v"
+    done < "$WORK/st_$db.txt"
+done
+if [[ "$FAIL" == "$FAIL_BEFORE" ]]; then
+    ok "位域值域均为合法 bigint（源库历史值与新扫描值内容不同属预期）"
+fi
+
+echo "=== 4/6 时间戳格式（类型/抽样）==="
+: > "$WORK/types.txt"
+for db in "$DB_A" "$DB_B"; do
+    t=$(psql "$PGURL_NOPASS_SERVER/$db$PGURL_QUERY" -Atc "SELECT DISTINCT data_type FROM information_schema.columns WHERE table_name='video' AND column_name IN ('ctime','created_at');")
+    s=$(psql "$PGURL_NOPASS_SERVER/$db$PGURL_QUERY" -Atc "SELECT to_char(ctime,'YYYY-MM-DD HH24:MI:SS.US') FROM video ORDER BY id LIMIT 2;")
+    echo "-- $db 类型: $t"
+    echo "-- $db 抽样: $(echo "$s" | tr '\n' ' ')"
+    echo "$t" >> "$WORK/types.txt"
+done
+if [[ "$(sort -u "$WORK/types.txt" | grep -c .)" == "1" ]] && grep -q 'timestamp without time zone' "$WORK/types.txt"; then
+    ok "两库时间戳类型一致（timestamp without time zone），抽样格式合法"
+else
+    bad "时间戳类型不一致: [$(tr '\n' ' ' < "$WORK/types.txt")]"
+fi
+
+echo "=== 5/6 JSON 结构（jsonb/json 列存在性与可解析）==="
+for db in "$DB_A" "$DB_B"; do
+    psql "$PGURL_NOPASS_SERVER/$db$PGURL_QUERY" -Atc \
+        "SELECT table_name || '.' || column_name || ':' || data_type FROM information_schema.columns
+         WHERE table_schema='public' AND data_type IN ('json','jsonb') ORDER BY 1;" > "$WORK/json_$db.txt"
+    echo "-- $db json 列: $(tr '\n' ' ' < "$WORK/json_$db.txt")"
+    # 抽样解析：无数据时跳过（jq -e 对空输入以非 0 退出，会误报解析失败）
+    tags=$(psql "$PGURL_NOPASS_SERVER/$db$PGURL_QUERY" -Atc "SELECT tags::text FROM video WHERE tags IS NOT NULL LIMIT 1;")
+    if [[ -z "$tags" ]]; then
+        echo "  -- $db video.tags 无数据，跳过解析"
+    elif echo "$tags" | jq -e . > /dev/null 2>&1; then
+        ok "$db video.tags 可解析"
+    else
+        bad "$db video.tags 解析失败"
+    fi
+done
+
+echo "=== 6/6 config 凭证三方一致（PG 源 → SQLite → 迁回 PG，credential 五字段 md5）==="
+cred_md5() { # $1=数据来源（pg库名|sqlite路径），输出 5 字段拼接串（供 md5，不进终端明文）
+    local src="$1"
+    if [[ "$src" == sqlite:* ]]; then
+        sqlite3 "${src#sqlite:}" "SELECT json_extract(data,'\$.credential.sessdata') || '|' || json_extract(data,'\$.credential.bili_jct') || '|' || json_extract(data,'\$.credential.dedeuserid') || '|' || json_extract(data,'\$.credential.buvid3') || '|' || json_extract(data,'\$.credential.ac_time_value') FROM config WHERE id=1;"
+    else
+        # 每个字段提取用括号包裹，避免 jsonb 运算符与 || 的优先级问题
+        psql "$PGURL_NOPASS_SERVER/$src$PGURL_QUERY" -Atc "SELECT (data::jsonb->'credential'->>'sessdata') || '|' || (data::jsonb->'credential'->>'bili_jct') || '|' || (data::jsonb->'credential'->>'dedeuserid') || '|' || (data::jsonb->'credential'->>'buvid3') || '|' || (data::jsonb->'credential'->>'ac_time_value') FROM config WHERE id=1;"
+    fi
+}
+M_A=$(cred_md5 "$DB_A" | md5)
+M_S=$(cred_md5 "sqlite:$SQLITE_DB" | md5)
+M_B=$(cred_md5 "$DB_B" | md5)
+echo "  源PG($DB_A)=$M_A  SQLite=$M_S  迁移后($DB_B)=$M_B"
+if [[ "$M_A" == "$M_S" && "$M_S" == "$M_B" ]]; then
+    ok "credential 五字段三方 md5 完全一致"
+else
+    if [[ "$M_S" == "$M_B" ]]; then
+        ok "SQLite 与迁移后一致；源PG差异属预期（迁移前的测试操作改过 config，如 interval/路径）"
+    else
+        bad "credential 三方不一致（SQLite ≠ 迁移后）"
+    fi
+fi
+
+echo ""
+echo "数据格式对比结果: PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/scripts/db-migrate/compare-ddl.sh
+++ b/scripts/db-migrate/compare-ddl.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# compare-ddl.sh — DDL 层对比：迁移后库 vs 现有 PG 库（阶段 D1）
+#
+# 用途：判定迁移目标库的 schema 与 bili-sync 迁移产物完全一致。
+# 方法：pg_dump --schema-only 两库后 diff。
+#
+# 说明：现有库（如 bili_sync）可能含迁移文件之外的手工测试残留表
+# （如 tz_probe），对比前剔除并说明，不视为 DDL 差异。
+#
+# 用法：
+#   compare-ddl.sh <PGURL> <库A> <库B> [--keep-workdir]
+
+set -euo pipefail
+
+PGURL="${1:?用法: compare-ddl.sh <PGURL> <库A> <库B>}"
+DB_A="${2:?缺库A（基准，如 bili_sync）}"
+DB_B="${3:?缺库B（迁移后，如 bili_migrate_test）}"
+[[ "${4:-}" == "--keep-workdir" ]] && KEEP=1
+
+# 从公共库加载 PGURL 结构切分（提取库名/服务器段/query 参数）
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib-pgurl.sh"
+split_pgurl
+# 密码改经 PGPASSWORD 传递：pg_dump 的 argv 会被 `ps` 全程可见，一律用 PGURL_NOPASS_SERVER
+strip_pg_password
+
+PASS=0; FAIL=0
+ok()  { echo "  ✓ $1"; PASS=$((PASS+1)); }
+bad() { echo "  ✗ $1"; FAIL=$((FAIL+1)); }
+
+WORK="$(mktemp -d /tmp/ddl-cmp.XXXXXX)"
+trap '[[ "${KEEP:-}" != 1 ]] && rm -rf "$WORK"' EXIT
+
+strip_tz_probe() { # 剔除 tz_probe 建表段（遗留手工表，见 memory: 时区探针测试残留）
+    awk '
+        /^CREATE TABLE public\.tz_probe/ { skip=1 }
+        skip && /^\);$/ { skip=0; print "-- [剔除] 手工残留表 tz_probe（不在迁移文件中，属测试遗留，非 DDL 差异）"; next }
+        !skip { print }
+    ' "$1" > "$2"
+}
+
+strip_dump_noise() { # $1=输入 $2=输出；剔除 pg_dump 17 每次随机生成的 restrict 令牌（与 schema 无关，直接 diff 会恒定误报）
+    sed -e '/^\\restrict /d' -e '/^\\unrestrict /d' "$1" > "$2"
+}
+
+echo "=== pg_dump schema-only ==="
+# 不吞 stderr：pg_dump 失败（如库名打错）时保留错误输出，set -e 中止也可见原因
+pg_dump -s --no-owner "$PGURL_NOPASS_SERVER/$DB_A$PGURL_QUERY" > "$WORK/a.sql"
+pg_dump -s --no-owner "$PGURL_NOPASS_SERVER/$DB_B$PGURL_QUERY" > "$WORK/b.sql"
+echo "库A($DB_A) dump: $(wc -l < "$WORK/a.sql") 行；库B($DB_B) dump: $(wc -l < "$WORK/b.sql") 行"
+
+# 库A 若有 tz_probe 则剔除（库B 由迁移生成，天然不含）；两库均剔除 dump 噪声
+if grep -q 'CREATE TABLE public.tz_probe' "$WORK/a.sql"; then
+    echo "检测到库A含 tz_probe 残留表，已剔除"
+    strip_tz_probe "$WORK/a.sql" "$WORK/a.tmp.sql"
+else
+    cp "$WORK/a.sql" "$WORK/a.tmp.sql"
+fi
+strip_dump_noise "$WORK/a.tmp.sql" "$WORK/a.clean.sql"
+strip_dump_noise "$WORK/b.sql" "$WORK/b.clean.sql"
+A_FILE="$WORK/a.clean.sql"
+B_FILE="$WORK/b.clean.sql"
+
+echo "=== diff -u（空输出=完全一致）==="
+if diff -u "$A_FILE" "$B_FILE" > "$WORK/diff.txt"; then
+    ok "DDL 完全一致"
+else
+    bad "存在差异（见下）:"
+    cat "$WORK/diff.txt"
+fi
+
+echo "=== 关键 DDL 抽查 ==="
+echo "--- 库B idx_video_unique ---"
+grep -A3 'idx_video_unique' "$B_FILE" | head -4
+echo "--- 库B created_at 默认值 ---"
+grep 'CURRENT_TIMESTAMP AT TIME ZONE' "$B_FILE" | head -2
+echo "--- 库B favorite latest_row_at 默认值 ---"
+grep "'1970-01-01 00:00:00'" "$B_FILE" | head -1
+
+echo ""
+echo "DDL 对比结果: PASS=$PASS FAIL=$FAIL"
+# 与 reconcile.sh / compare-data.sh 对齐：存在差异必须以非零退出，
+# 否则串联执行（A && B）或接入 CI 时 schema 漂移会静默通过
+[[ $FAIL -eq 0 ]] || exit 1

--- a/scripts/db-migrate/gen-migrate-conf.sh
+++ b/scripts/db-migrate/gen-migrate-conf.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# gen-migrate-conf.sh — 动态生成 pgloader 迁移配置（表清单 + cast 规则），不手写清单
+#
+# 设计原则（单一事实来源）：目标库 schema 由 bili-sync 自己的 sea-orm 迁移生成，
+# 是实体代码的镜像。表清单从目标库 pg_tables 推导、cast 规则从 information_schema
+# 的 data_type 集合推导——维护者给实体加表/加列后，目标库（迁移自动建好）里就有，
+# 重跑本脚本即得到新的迁移配置，无需修改任何"迁移配置清单"。
+#
+# 唯一需人工维护的点：SEAQ_ORM_TYPE_MAP（sea-query 的确定性类型映射）。
+# 仅当未来 sea-query 支持新的列类型映射时才需更新（集中在下方常量处）。
+# 目标库出现未映射的列类型时脚本直接报错退出（fail-closed），
+# 不会带着 pgloader 的未知默认转换继续——保真优先。
+#
+# 用法：
+#   gen-migrate-conf.sh <PGURL> <SQLITE_DB> <输出 .load 文件>
+
+set -euo pipefail
+
+PGURL="${1:?用法: gen-migrate-conf.sh <PGURL> <SQLITE_DB> <输出>}"
+SQLITE_DB="${2:?缺 SQLITE_DB}"
+OUT="${3:?缺输出文件}"
+# FROM 必须写绝对路径：相对路径会被 pgloader 按 .load 文件所在目录解析（3.6.7 实测），
+# sqlite3 驱动对不存在路径会自动建空库文件——「零错误零行数」假成功，靠 C5 对账才兜住。
+# 存在性不能依赖 realpath 退出码：coreutils 9.10 对不存在的路径也返回 0（-m 语义），
+# 需显式 -f 守卫
+SQLITE_DB_ABS="$(realpath "$SQLITE_DB")"
+[[ -f "$SQLITE_DB_ABS" ]] || { echo "错误: SQLite 库不存在: $SQLITE_DB_ABS" >&2; exit 1; }
+
+# 从公共库加载 PGURL 结构切分（提取库名/服务器段/query 参数）
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib-pgurl.sh"
+split_pgurl
+# 密码改经 PGPASSWORD 传递：psql 的 argv 会被 `ps` 全程可见，一律用 PGURL_NOPASS；
+# INTO 串（写进 .load 文件）保留完整 URL——pgloader 从文件读取、不经 argv，
+# 且生成后文件会收紧为 0600
+strip_pg_password
+# 库名从连接串提取（必须带库名）
+[[ -n "$PGURL_DB" ]] || { echo "错误: 连接串缺少库名（连接串需形如 postgres://user:pass@host:5432/db）" >&2; exit 1; }
+TARGET_DB="$PGURL_DB"
+
+# sea-query 0.32.7 确定性类型映射（PG data_type → SQLite 声明类型名）
+# 依据 crates/bili_sync_migration 与 sea-query SQLite 后端渲染行为核对
+# 注意 character varying 的 SQLite 声明类型是 varchar（sea-query SQLite 后端对
+# ColumnType::String 渲染为 varchar）。映射错误会生成与源列类型不匹配的 cast 规则：
+# 源库 varchar 列匹配不到任何规则（退回 pgloader 默认转换并刷 WARNING），
+# 源库 text 列（config.data）则会同时匹配两条同名规则，走哪条无保证。
+SEAQ_ORM_TYPE_MAP=(
+    "timestamp without time zone|timestamp_text"
+    "json|json_text"
+    "jsonb|jsonb_text"
+    "boolean|boolean"
+    "bigint|bigint"
+    "integer|integer"
+    "smallint|smallint"
+    "text|text"
+    "character varying|varchar"
+    "character|char"
+)
+
+# --- 1. 表清单：从目标库动态推导（排除 seaql_migrations） ------------------------
+TABLES=$(psql "$PGURL_NOPASS" -Atc \
+    "SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename<>'seaql_migrations' ORDER BY tablename;")
+test -n "$TABLES" || { echo "错误: 目标库 $TARGET_DB 无业务表（请先用 bili-sync 启动建 schema）"; exit 1; }
+
+# --- 2. cast 规则：从目标库 data_type 集合推导 ------------------------------------
+TYPES=$(psql "$PGURL_NOPASS" -Atc \
+    "SELECT DISTINCT data_type FROM information_schema.columns
+     WHERE table_schema='public' AND table_name<>'seaql_migrations' ORDER BY 1;")
+
+# pgloader 不接受带空格的目标类型名（实测 3.6.10），PG data_type → cast 目标名
+PG_CAST_TYPE_MAP=(
+    "timestamp without time zone|timestamp"
+    "character varying|varchar"
+    "character|varchar"
+)
+
+cast_rule() { # $1=PG data_type，输出 pgloader cast 行（未映射时输出空串，由调用方汇总后报错）
+    local pg_type="$1" sqlite_type="" cast_type=""
+    for pair in "${SEAQ_ORM_TYPE_MAP[@]}"; do
+        if [[ "$pg_type" == "${pair%%|*}" ]]; then
+            sqlite_type="${pair##*|}"
+            break
+        fi
+    done
+    for pair in "${PG_CAST_TYPE_MAP[@]}"; do
+        if [[ "$pg_type" == "${pair%%|*}" ]]; then
+            cast_type="${pair##*|}"
+            break
+        fi
+    done
+    cast_type="${cast_type:-$pg_type}"
+    if [[ -n "$sqlite_type" ]]; then
+        echo "    type $sqlite_type to $cast_type drop typemod"
+    fi
+}
+
+# --- 3. 推导 cast 规则（先于写文件：未映射类型 fail-closed，不留半成品 .load） ------
+rules=()
+unmapped_types=()
+while read -r t; do
+    rule=$(cast_rule "$t")
+    if [[ -n "$rule" ]]; then
+        rules+=("$rule")
+    else
+        unmapped_types+=("$t")
+    fi
+done <<< "$TYPES"
+# 未映射类型不允许带着未知转换继续：pgloader 会退回默认转换，可能静默改写值，
+# 而它行级失败 exit 0、migrate.sh 行数对账也捕捉不到值级损坏——保真工具链必须失败关闭
+if [[ ${#unmapped_types[@]} -gt 0 ]]; then
+    echo "错误: 以下 PG 列类型在 SEAQ_ORM_TYPE_MAP 中无映射:" >&2
+    printf '      %s\n' "${unmapped_types[@]}" >&2
+    echo "      实体新增列类型时需同步更新 SEAQ_ORM_TYPE_MAP（本文件顶部）" >&2
+    exit 1
+fi
+
+# --- 4. 生成 .load 文件 ------------------------------------------------------------
+{
+    # pgloader 的 INTO 需完整连接串（postgresql:// 空 URI 会解析失败）；
+    # 不带 query 参数：pgloader 的 URI 参数白名单只有 sslmode/host/port/dbname/user/
+    # password/tablename（uri-param 类参数作末参数还会吞掉 .load 后续内容），连接参数
+    # 经 PGSSLMODE 环境变量传递（migrate.sh 导出，pgloader 的环境变量也只认这一个）
+    INTO_URL="${PGURL/postgres:\/\//postgresql://}"
+    INTO_URL="${INTO_URL%%\?*}"
+    echo "LOAD DATABASE"
+    echo "    FROM sqlite://$SQLITE_DB_ABS"
+    echo "    INTO $INTO_URL"
+    echo ""
+    echo "WITH create no tables, reset sequences"
+    echo ""
+    echo "SET PostgreSQL PARAMETERS"
+    echo "    maintenance_work_mem = '128MB'"
+    echo ""
+    echo "CAST"
+    # pgloader 多条 cast 规则间需逗号分隔（最后一条后换行接分号）；
+    # 逗号按「实际输出的规则数」计算（未映射类型已在上面拦截，不会留下悬空逗号）
+    if [[ ${#rules[@]} -gt 0 ]]; then
+        for ((idx = 0; idx < ${#rules[@]} - 1; idx++)); do
+            echo "${rules[$idx]},"
+        done
+        echo "${rules[-1]}"
+    fi
+    echo ""
+    # 排除迁移记录表（seaql_migrations 不随迁，目标库由 bili-sync 自己的迁移建）
+    # 语法注意（pgloader 3.6 实测）：EXCLUDING 必须是 LOAD DATABASE 的子句（分号之前），
+    # 关键字是 LIKE 且只接受一个 SQL LIKE 模式；sqlite_ 内部表由 pgloader 驱动自动跳过
+    echo "EXCLUDING TABLE NAMES LIKE 'seaql_migrations'"
+    echo ";"
+} > "$OUT"
+# .load 的 INTO 串含明文密码（pgloader 从文件读取、不经 argv），
+# 重定向按 umask 生成 0644——收紧为仅所有者可读写
+chmod 600 "$OUT"
+
+echo "已生成迁移配置: $OUT"
+echo "--- 表清单（$(echo "$TABLES" | wc -l) 张，自动推导）---"
+echo "$TABLES"
+echo "--- cast 规则（$(echo "$TYPES" | wc -l) 种类型，自动推导）---"
+grep -E '^    type ' "$OUT" || true

--- a/scripts/db-migrate/inject-credential.sh
+++ b/scripts/db-migrate/inject-credential.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# inject-credential.sh — 从 PostgreSQL config 表提取整份配置注入 SQLite config 表（整体替换 data 列）
+#
+# 用途：SQLite→PG 迁移实测验证的阶段 A（A1-A2）。
+#   以 PostgreSQL 后端跑过 bili-sync 的库（如 bili_sync）中存有真实登录凭证，
+#   本脚本将其中 config 行（id=1, data 为整份 JSON）原样搬入 SQLite 库，
+#   使 SQLite 后端得以用真实凭证运行，生成真实形态的迁移源数据。
+#
+# 用法：
+#   inject-credential.sh <PGURL> <SQLITE_DB> [工作目录]
+#   不传工作目录时使用 mktemp -d（0700，退出自动清理，凭据不落盘）；
+#   传入工作目录时目录由用户管理，脚本异常退出会提示清理。
+#
+# 前置条件：
+#   - SQLite 库已由 bili-sync 首次启动建好（存在 config 表）
+#   - psql / sqlite3 / jq 可用
+#
+# 凭证安全约定：密码经 PGPASSWORD 传递（不进 argv），凭证明文只落工作目录，
+# 注入经 stdin 传入 sqlite3（不进 argv）；终端只输出 md5 与存在性矩阵（布尔/长度）。
+
+set -euo pipefail
+
+PGURL="${1:?用法: inject-credential.sh <PGURL> <SQLITE_DB> [工作目录]}"
+SQLITE_DB="${2:?缺 SQLITE_DB}"
+WORK="${3:-}"
+
+
+# 从公共库加载 PGURL 结构切分（提取库名/服务器段/query 参数）
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib-pgurl.sh"
+split_pgurl
+# 密码改经 PGPASSWORD 传递：psql 的 argv 会被 `ps` 全程可见，一律用 PGURL_NOPASS_SERVER
+strip_pg_password
+# PG 侧库名：优先连接串里的库名，其次 PG_DB 环境变量（旧约定后备），缺省 bili_sync
+PG_DB="${PGURL_DB:-${PG_DB:-bili_sync}}"
+
+if [[ -n "$WORK" ]]; then
+    WORK_USER_KEEP=1
+    mkdir -p "$WORK"
+    # 用户指定工作目录：脚本异常退出时提醒清理，不自动删除（目录由用户管理）
+    trap '[[ $? -ne 0 ]] && [[ -f "$WORK/config_src.json" ]] && echo "注意: 异常退出，凭证明文残留于 $WORK/config_src.json，请及时清理" >&2' EXIT
+else
+    # 默认使用 mktemp -d（0700 仅当前用户可读）：退出即自动清理，凭证明文不落盘
+    WORK="$(mktemp -d)"
+    trap 'rm -rf "$WORK"' EXIT
+fi
+
+# --- 1. 从 PG 提取 config 行（直落文件，不进终端） --------------------------------
+# 不能用 COPY TO STDOUT：COPY 文本格式会把数据内的反斜杠/换行转义，
+# 凭证含这些字节时会静默损坏；SELECT 原样输出（末尾带一个行尾换行，与 SQLite 侧一致）
+psql "$PGURL_NOPASS_SERVER/$PG_DB$PGURL_QUERY" -Atc "SELECT data FROM config WHERE id=1" > "$WORK/config_src.json" 2>/dev/null \
+    || { echo "错误: 读取 PG 侧 config 失败（库 $PG_DB 无 config 表？）"; exit 1; }
+test -s "$WORK/config_src.json" || { echo "错误: PG 侧 config 为空"; exit 1; }
+
+# --- 2. JSON 有效性 + credential 存在性矩阵（只打印布尔/长度） --------------------
+jq -e . "$WORK/config_src.json" > /dev/null || { echo "错误: PG config 不是合法 JSON"; exit 1; }
+
+cred_matrix() { # $1=config JSON 文件
+    jq -c -e '.credential | {
+        sessdata:   (.sessdata   | type == "string" and length > 0),
+        bili_jct:   (.bili_jct   | type == "string" and length > 0),
+        dedeuserid: (.dedeuserid | type == "string" and length > 0),
+        buvid3:     (.buvid3     | type == "string" and length > 0),
+        ac_time_value: (.ac_time_value | type == "string" and length > 0),
+    }' "$1"
+}
+
+echo "[1/5] PG config 提取完成 (md5=$(md5sum "$WORK/config_src.json" | cut -d' ' -f1))"
+cred_matrix "$WORK/config_src.json" | jq . > "$WORK/matrix_pg.json"
+cat "$WORK/matrix_pg.json"
+
+# --- 3. 校验 SQLite 库与 config 表存在 -------------------------------------------
+[[ -f "$SQLITE_DB" ]] || { echo "错误: SQLite 库不存在: $SQLITE_DB（请先用 bili-sync 首次启动建库）"; exit 1; }
+sqlite3 "$SQLITE_DB" "SELECT count(*) FROM config;" > /dev/null 2>&1 \
+    || { echo "错误: SQLite 库 $SQLITE_DB 无 config 表，请先用 bili-sync 首次启动建库"; exit 1; }
+
+# --- 4. 注入：SQL 单引号转义后经 stdin 传入，整体替换 data 列 ----------------------
+# SQL 字符串字面量用单引号包裹，JSON 中出现的单引号双写（''）即可；
+# 双引号/反斜杠在 SQL 字符串中无特殊含义，原样保留。
+# 整份凭证明文经 heredoc 管道（stdin）进入 sqlite3，而非命令行参数——
+# 后者会被 `ps` 全程可见；$(sed ...) 同时剥掉 psql 输出末尾的换行（与历史语义一致）
+SQLITE_ESCAPED=$(sed "s/'/''/g" "$WORK/config_src.json")
+sqlite3 "$SQLITE_DB" <<SQL || { echo "错误: SQLite 注入失败"; exit 1; }
+UPDATE config SET data = '$SQLITE_ESCAPED' WHERE id = 1;
+SQL
+echo "[2/5] 注入完成: UPDATE config SET data=<整份 JSON> WHERE id=1"
+
+# --- 5. SQLite 侧校验：json_valid + 矩阵一致 + md5 一致 ----------------------------
+sqlite3 "$SQLITE_DB" "SELECT json_valid(data) FROM config WHERE id=1;" | grep -qx 1 \
+    || { echo "错误: SQLite config.data 不是合法 JSON"; exit 1; }
+sqlite3 "$SQLITE_DB" "SELECT data FROM config WHERE id=1;" > "$WORK/config_sqlite.json"
+md5sum "$WORK/config_sqlite.json" | cut -d' ' -f1 > "$WORK/md5_sqlite.txt"
+md5sum "$WORK/config_src.json" | cut -d' ' -f1 > "$WORK/md5_pg.txt"
+
+cred_matrix "$WORK/config_sqlite.json" | jq . > "$WORK/matrix_sqlite.json"
+echo "[3/5] SQLite 侧矩阵:"
+cat "$WORK/matrix_sqlite.json"
+
+if diff -q "$WORK/matrix_pg.json" "$WORK/matrix_sqlite.json" > /dev/null; then
+    echo "[4/5] credential 存在性矩阵: 一致"
+else
+    echo "[4/5] credential 存在性矩阵: 不一致!"; exit 1
+fi
+
+if diff -q "$WORK/md5_pg.txt" "$WORK/md5_sqlite.txt" > /dev/null; then
+    echo "[5/5] config 字节级一致 (md5=$(cat "$WORK/md5_pg.txt"))"
+else
+    # 两侧均为 SELECT 原样输出（无 COPY 转义问题，见步骤 1 的说明），
+    # 不存在「合法的不一致」：任何字节差异都意味着注入过程改写了数据
+    echo "[5/5] 错误: md5 不一致，注入过程改写了 config 数据" >&2
+    exit 1
+fi
+
+if [[ -n "${WORK_USER_KEEP:-}" ]]; then
+    echo "完成。工作目录: $WORK（含凭证明文，验证结束后请清理）"
+else
+    echo "完成。临时工作目录已自动清理"
+fi

--- a/scripts/db-migrate/lib-pgurl.sh
+++ b/scripts/db-migrate/lib-pgurl.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# lib-pgurl.sh — PGURL 结构切分公共函数（供 db-migrate 工具链各脚本 source）
+#
+# 不解析、不转义任何字符，只在结构位置切分（对合法 URL 安全）：
+#   1) query 段：第一个未编码 ? 之后全部原样保留（内部再含 ?、多参数 & 均不受影响）
+#   2) 库名段：authority（// 之后、第一个 / 之前）之后的第一个 / 起视为 dbname——
+#      数据库名就在连接串里（各工具的自然用法），脚本提取出来供拼接使用
+#
+# 调用后设置：
+#   PGURL_SERVER — 服务器级连接串（无库名、无 query、无尾斜杠）
+#   PGURL_DB     — 库名（连接串未带库名时为空串，调用方按需校验）
+#   PGURL_QUERY  — query 段（含前导 ?；无参数时为空串）
+split_pgurl() {
+    PGURL_BASE="${PGURL%%\?*}"
+    PGURL_BASE="${PGURL_BASE%/}"
+    local rest="${PGURL_BASE#*//}"
+    case "$rest" in
+        */*)
+            PGURL_DB="${rest#*/}"
+            PGURL_SERVER="${PGURL_BASE%/*}"
+            ;;
+        *)
+            PGURL_DB=""
+            PGURL_SERVER="$PGURL_BASE"
+            ;;
+    esac
+    PGURL_QUERY=""
+    # 不能用「[[ ]] && 赋值」收尾：URL 无 query 时条件为假会使函数返回 1，
+    # set -e 的调用方会静默退出（普通无参数 URL 全部中招，实测踩坑）
+    if [[ "$PGURL" == *\?* ]]; then
+        PGURL_QUERY="?${PGURL#*\?}"
+    fi
+}
+
+# percent-decode：把 %XX 还原为对应字节（仅用于密码，密码可能含 URL 保留字符；
+# 未编码的 % 或非法十六进制原样保留）。每个 %XX 单独经 printf '%b' 解码，
+# 解码产物不会再次被转义解释（字面反斜杠/十六进制文本原样拼接）
+pgurl_percent_decode() {
+    local s="$1" out="" c
+    while [[ -n "$s" ]]; do
+        if [[ "$s" == %[0-9A-Fa-f][0-9A-Fa-f]* ]]; then
+            out+="$(printf '%b' "\\x${s:1:2}")"
+            s="${s:3}"
+        else
+            c="${s:0:1}"
+            out+="$c"
+            s="${s:1}"
+        fi
+    done
+    printf '%s' "$out"
+}
+
+# 剥离连接串中的密码段并导出 PGPASSWORD（供 psql/pg_dump 等 libpq 客户端使用）。
+# 动机：带密码的完整连接串直接作 psql/pg_dump 的 argv 会全程暴露在 `ps` 输出里；
+# libpq 的 URL 密码优先级高于 PGPASSWORD，必须同时从 URL 中移除密码段。
+#
+# 调用前需先设置 PGURL（并已调用 split_pgurl），调用后：
+#   PGPASSWORD          — percent-decode 后的密码（URL 未带密码时不导出，保留外部环境值）
+#   PGURL_NOPASS        — 完整连接串剥离密码段（query 保留）
+#   PGURL_NOPASS_SERVER — 服务器级连接串剥离密码段（无库名/query/尾斜杠）
+strip_pg_password() {
+    local base="${PGURL%%\?*}"
+    base="${base%/}"
+    # userinfo 段：authority 中第一个未编码 @ 之前的部分；
+    # 无 @ 时是 host[:port]（如 postgres://host:5432/db），不是 user:pass，不可拆
+    local authority="${base#*//}"
+    local userinfo="${authority%%/*}"
+    if [[ "$userinfo" == *@* ]]; then
+        local cred="${userinfo%%@*}"   # user:pass（user 可能为空，如 :pass@host）
+        local base_nopass="$base"
+        if [[ "$cred" == *:* ]]; then
+            PGPASSWORD="$(pgurl_percent_decode "${cred#*:}")"
+            export PGPASSWORD
+            # 重建无密码 URL：保留 user，去掉 :pass 段
+            base_nopass="${base%%//*}//${cred%%:*}@${authority#*@}"
+        fi
+        PGURL_NOPASS="$base_nopass${PGURL#"$base"}"
+        PGURL_NOPASS_SERVER="${base_nopass%/*}"
+    else
+        # 无 userinfo：URL 原样保留（外部 PGPASSWORD 若存在则继续生效），只派生服务器段
+        PGURL_NOPASS="$PGURL"
+        PGURL_NOPASS_SERVER="${base%/*}"
+    fi
+}

--- a/scripts/db-migrate/migrate.sh
+++ b/scripts/db-migrate/migrate.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# migrate.sh — SQLite→PostgreSQL data-only 迁移（外部工具实测）
+#
+# 流程（对应计划阶段 C1-C5）：
+#   1. 校验/准备目标库：不 DROP 数据库，目标库需为空（无表）或加 --force 清空库内表；
+#      库不存在时默认报错退出（自动建库需 --create-db 显式开启）
+#   2. 用 bili-sync 启动一次让 sea-orm 迁移建 schema（PG 视为全新安装，全量 Migrator::up）
+#   3. TRUNCATE 业务表 RESTART IDENTITY（清掉 VersionedConfig::init 自动插入的默认 config 行）
+#   4. gen-migrate-conf.sh 动态生成 pgloader 配置（表清单/cast 全推导，不手写）并执行导入
+#   5. 序列对齐 + 行数对账（pgloader 行级错误不反映到退出码，必须显式验证）
+#
+# 用法：
+#   migrate.sh <PGURL> <SQLITE_DB> <BILI_SYNC_BIN> [--config-dir <dir>] [--force] [--create-db]
+#
+# PGURL 为完整连接串（含库名与可选 query 参数），目标库名从连接串提取。
+# 导入工具固定为 pgloader（唯一实测验证过的工具）。
+# 安全约定：脚本不 DROP 数据库，目标库由用户提供；已有表时默认拒绝清库
+# （防止库名打错清掉生产库），确认目标库可清空后加 --force（只清库内表，
+# 数据库本体与其他对象永不被删除）。目标库不存在时同样默认不自动创建
+# （防止库名打错把数据迁进新建的错误库），自动建库需 --create-db（需 CREATEDB 权限）。
+#
+# 环境变量：PGURL、SQLITE_DB、BILI_SYNC_BIN 亦可通过环境变量传入。
+
+set -euo pipefail
+
+# 可选参数：--config-dir、--force、--create-db（也支持环境变量 CONFIG_DIR）
+FORCE=0
+CREATE_DB=0
+# 自建的临时 config 目录单独记录：--config-dir 会在参数解析时覆盖 CONFIG_DIR，
+# 若只记在 CONFIG_DIR 上，覆盖后 trap 就找不到待删的临时目录（泄漏空目录）
+TMP_CONFIG_DIR=""
+if [[ -z "${CONFIG_DIR:-}" ]]; then
+    TMP_CONFIG_DIR="$(mktemp -d)"
+    CONFIG_DIR="$TMP_CONFIG_DIR"
+fi
+# 清理 trap 在临时目录创建后立即安装：参数解析/依赖校验存在多条提前退出路径，
+# 装晚了会让自建的临时目录在报错退出时泄漏（TMP_DIR 晚于此创建，用判空守卫）
+trap 'if [[ -n "${TMP_CONFIG_DIR:-}" ]]; then rm -rf "$TMP_CONFIG_DIR"; fi; if [[ -n "${TMP_DIR:-}" ]]; then rm -rf "$TMP_DIR"; fi' EXIT
+
+if [[ "${1:-}" == --* ]]; then
+    # 全部走环境变量 + 可选 flag 的调用形式
+    PGURL="${PGURL:?缺 PGURL（环境变量或位置参数）}"
+    SQLITE_DB="${SQLITE_DB:?缺 SQLITE_DB}"
+    BIN="${BILI_SYNC_BIN:?缺 bili-sync 二进制}"
+else
+    PGURL="${1:-${PGURL:?用法: migrate.sh <PGURL> <SQLITE_DB> <BILI_SYNC_BIN> [--config-dir <dir>] [--force] [--create-db]}}"
+    SQLITE_DB="${2:-${SQLITE_DB:?缺 SQLITE_DB}}"
+    BIN="${3:-${BILI_SYNC_BIN:?缺 bili-sync 二进制}}"
+    # 位置参数不足 3 个时（BIN 走环境变量），shift 3 会以 "shift count out of range"
+    # 裸崩——回退为清空剩余位置参数
+    shift 3 2>/dev/null || shift $#
+fi
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --config-dir) CONFIG_DIR="${2:?--config-dir 缺参数}"; shift 2 ;;
+        --force) FORCE=1; shift ;;
+        --create-db) CREATE_DB=1; shift ;;
+        *) echo "未知参数: $1" >&2; exit 1 ;;
+    esac
+done
+
+# 从公共库加载 PGURL 结构切分（提取库名/服务器段/query 参数）
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib-pgurl.sh"
+split_pgurl
+# 数据库名必须在连接串里（各工具的自然用法），缺库名直接拒绝
+[[ -n "$PGURL_DB" ]] || { echo "错误: 连接串缺少库名（连接串需形如 postgres://user:pass@host:5432/db）" >&2; exit 1; }
+# 密码改经 PGPASSWORD 传递：psql/pg_dump 的 argv 会被 `ps` 全程可见，
+# 后续所有 psql 调用一律用 PGURL_NOPASS
+strip_pg_password
+
+# bili-sync 经 sqlx 连接，不读 PGPASSWORD 环境变量，密码必须留在 URL 里；
+# 仅此一处使用完整连接串（进程短暂存在），其余 psql 调用一律用 PGURL_NOPASS
+DB_URL="$PGURL"
+
+# query 参数与 pgloader 的兼容性（2026-08-29 源码核对 + TLS 沙箱实测，pgloader 3.6.10）：
+# pgloader 用 postmodern+CL+SSL 连 PG（不走 libpq），.load 的 INTO 串不带 query——
+# 其 URI 参数白名单只有 sslmode/host/port/dbname/user/password/tablename，且 uri-param
+# 类参数作末参数会把 .load 后续内容整个吞进参数值；环境变量里它也只读 PGSSLMODE 一个，
+# PGSSLROOTCERT/PGSSLCERT/PGSSLKEY/PGCONNECT_TIMEOUT/PGAPPNAME/PGOPTIONS 一概不读
+# （客户端证书只认硬编码 ~/.postgresql/postgresql.crt）。psql（libpq）与 bili-sync
+# （sqlx）直接消费 URL 参数，URL 优先级高于环境变量（libpq 标准），无需重复导出。
+if [[ -n "$PGURL_QUERY" ]]; then
+    IFS='&' read -r -a QPARAMS <<< "${PGURL_QUERY#\?}"
+    for kv in "${QPARAMS[@]}"; do
+        key="${kv%%=*}"; val="${kv#*=}"
+        case "$key" in
+            # 唯一能传给 pgloader 的通道（INTO 串无 query，靠 PGSSLMODE 兜底）
+            sslmode) export PGSSLMODE="$val" ;;
+            sslrootcert|sslcert|sslkey|application_name|options)
+                echo "警告: pgloader 不消费连接参数 $key（它只读 PGSSLMODE），此参数仅对 psql/bili-sync 生效" >&2 ;;
+            sslpassword|connect_timeout)
+                echo "警告: pgloader 不消费连接参数 $key（它只读 PGSSLMODE），sqlx 也不识别该参数，仅 psql 生效" >&2 ;;
+            *) echo "警告: 忽略 pgloader 不支持的连接参数: $key" >&2 ;;
+        esac
+    done
+fi
+# pgloader 的 PGSSLMODE 只认 disable/allow/prefer/require 四个值：verify-full/verify-ca
+# 会让它在 C4 解析 .load 时直接崩溃（exit 1）。值无论来自 URL 的 sslmode 还是外部
+# PGSSLMODE 环境变量，都在此提前拦截并给出可行替代
+case "${PGSSLMODE:-}" in
+    ""|disable|allow|prefer|require) ;;
+    *)
+        echo "错误: PGSSLMODE=$PGSSLMODE 与 pgloader 不兼容（其 URI/环境变量仅认 disable/allow/prefer/require，" >&2
+        echo "      verify-* 会让 pgloader 解析崩溃）。需要证书验证请改用 sslmode=require，并把 CA 装入" >&2
+        echo "      运行 pgloader 机器的系统信任库（update-ca-certificates）——注意 pgloader 的 require 会按" >&2
+        echo "      系统信任库验证服务器证书，与 libpq 的 require（只加密不验证）语义不同" >&2
+        exit 1
+        ;;
+esac
+
+[[ -f "$SQLITE_DB" ]] || { echo "错误: SQLite 库不存在: $SQLITE_DB" >&2; exit 1; }
+# sqlite3 缺失时下方的命令替换会产出空串、被误判为"非空"，必须显式前置检查（失败关闭）
+command -v sqlite3 >/dev/null 2>&1 || { echo "错误: 未安装 sqlite3（非空校验与行数对账需要）" >&2; exit 1; }
+# sqlite3/pgloader 连不存在路径会自动建空库文件，路径打错会把空库「迁移成功」——必须先验非空。
+# 排除集合与 C5 表清单一致（seaql_migrations + SQLite 内部表）：仅剩 seaql_migrations 的
+# 文件不是合法迁移源，放行会让 C5 表清单为空而打印假成功。
+# NOT GLOB 而非 NOT LIKE：LIKE 的 _ 是单字符通配符（sqlite_% 实际匹配 sqlite+任意字符），
+# GLOB 的 * 才按字面 sqlite_ 前缀匹配 SQLite 内部表
+[[ "$(sqlite3 "$SQLITE_DB" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name <> 'seaql_migrations' AND name NOT GLOB 'sqlite_*';")" != "0" ]] \
+    || { echo "错误: SQLite 库无业务表（空库或路径错误）: $SQLITE_DB" >&2; exit 1; }
+[[ -x "$BIN" ]] || { echo "错误: bili-sync 二进制不存在或不可执行: $BIN" >&2; exit 1; }
+command -v pgloader >/dev/null 2>&1 || { echo "错误: 未安装 pgloader" >&2; exit 1; }
+# psql 缺失时下方 `! psql ...` 会落入「目标库不存在或无法连接」分支误导排查——显式前置检查
+command -v psql >/dev/null 2>&1 || { echo "错误: 未安装 psql（校验/准备目标库需要）" >&2; exit 1; }
+
+TMP_DIR="$(mktemp -d /tmp/migrate-run.XXXXXX)"
+
+echo "=== C1 校验/准备目标库 $PGURL_DB（脚本不 DROP 数据库）==="
+# 目标库必须无表：bili-sync 的 sea-orm 迁移是全量建 schema 的前提
+# （增量迁移不会修正既有列定义，如旧库 created_at 默认值遗留问题）。
+# 不 DROP 数据库：目标库由用户提供（空库或允许清空的库），脚本最多清库内表，
+# 数据库本体与其他对象（扩展/角色等）永不被脚本删除
+if ! psql "$PGURL_NOPASS" -Atc "SELECT 1" >/dev/null 2>&1; then
+    # 连接失败通常是库不存在，也可能是密码错/连接参数有误。默认不自动建库：
+    # 库名打错时静默 CREATE DATABASE 会把数据迁进新建的错误库、真实目标毫发无损，
+    # 与「绝不 DROP」的谨慎不对称——自动建库需 --create-db 显式开启（需 CREATEDB 权限）
+    if [[ "$CREATE_DB" != 1 ]]; then
+        echo "错误: 目标库 $PGURL_DB 不存在或无法连接（库名错误或连接参数有误）" >&2
+        echo "      确认连接串后重试；确认要自动创建空库请加 --create-db，或手动执行:" >&2
+        echo "        CREATE DATABASE \"$PGURL_DB\";" >&2
+        exit 1
+    fi
+    if psql "$PGURL_NOPASS_SERVER/postgres$PGURL_QUERY" -c "CREATE DATABASE \"$PGURL_DB\";" > /dev/null 2>&1; then
+        echo "已创建空库 $PGURL_DB"
+    else
+        echo "错误: 目标库 $PGURL_DB 创建失败（权限不足或连接参数有误）" >&2
+        echo "      请先手动创建空库后重试" >&2
+        exit 1
+    fi
+fi
+table_count=$(psql "$PGURL_NOPASS" -Atc "SELECT count(*) FROM pg_tables WHERE schemaname='public';" 2>/dev/null || echo 0)
+if [[ "$table_count" != "0" ]]; then
+    if [[ "$FORCE" != 1 ]]; then
+        echo "错误: 目标库 $PGURL_DB 已有 $table_count 张表，拒绝清库" >&2
+        echo "      确认目标库可清空后加 --force 重试（清库内所有表，不删除数据库本身）" >&2
+        exit 1
+    fi
+    # --force：清空库内所有表（含 seaql_migrations——保留它会导致迁移按旧记录跳过建表）
+    # format('%I') 对表名加引号，避免非全小写表名被 PG 折叠后 DROP 落空；
+    # pg_tables 不含视图/物化视图，bili-sync 的库只有普通表，视图类残留不在清库范围
+    TABLES_DROP=$(psql "$PGURL_NOPASS" -Atc \
+        "SELECT string_agg(format('%I', tablename), ', ') FROM pg_tables WHERE schemaname='public';")
+    psql "$PGURL_NOPASS" -v ON_ERROR_STOP=1 -c "DROP TABLE IF EXISTS $TABLES_DROP CASCADE;" > /dev/null
+    echo "已清空目标库内所有表（数据库本体保留）"
+fi
+
+
+# 服务器开着 TLS 而 pgloader 侧未配 sslmode 时，pgloader 会静默以明文连接
+# （其 use-ssl 默认 :no；psql/bili-sync 默认会协商 TLS）——提前提醒，避免
+# 「迁移成功但导入这一腿走了明文」。SHOW ssl 对普通用户不可读时静默跳过
+if [[ -z "${PGSSLMODE:-}" ]] && [[ "$(psql "$PGURL_NOPASS" -Atc "SHOW ssl" 2>/dev/null)" == "on" ]]; then
+    echo "警告: 目标服务器已启用 TLS，但连接串未带 sslmode：pgloader 将以明文连接（psql/bili-sync 不受影响）" >&2
+    echo "      全链路 TLS 请加 sslmode=require（pgloader 按系统信任库验证证书，内部 CA 需先装入）" >&2
+fi
+
+echo "=== C2 bili-sync 建 schema（sea-orm 迁移）==="
+# 后台启动，等数据库初始化完成（迁移执行）后停止；首轮定时任务不触发（interval 默认较长）
+"$BIN" --config-dir "$CONFIG_DIR" --database-url "$DB_URL" --scan-only \
+    --log-level 'None,bili_sync=info' > "$TMP_DIR/app.log" 2>&1 &
+BIN_PID=$!
+READY=0
+for _ in $(seq 1 30); do
+    # 主判据：日志出现初始化完成（快路径）
+    grep -q '数据库初始化完成' "$TMP_DIR/app.log" 2>/dev/null && { READY=1; break; }
+    # 进程死亡优先检出（避免半建 schema 时被兜底判据误判就绪、掩盖真实报错）
+    kill -0 $BIN_PID 2>/dev/null || { echo "错误: bili-sync 提前退出"; tail -20 "$TMP_DIR/app.log" >&2; exit 1; }
+    # 兜底判据：目标库 schema 已建成（日志文案/级别变动时仍能就绪）
+    [[ "$(psql "$PGURL_NOPASS" -Atc "SELECT count(*) FROM pg_tables WHERE schemaname='public';" 2>/dev/null || echo 0)" != "0" ]] && { READY=1; break; }
+    sleep 1
+done
+kill $BIN_PID 2>/dev/null || true
+wait $BIN_PID 2>/dev/null || true
+sleep 1
+[[ "$READY" == 1 ]] || { echo "错误: 等待数据库初始化就绪超时（30s，未见日志信号或 schema）"; tail -20 "$TMP_DIR/app.log" >&2; exit 1; }
+if ! grep -q '数据库初始化完成' "$TMP_DIR/app.log" 2>/dev/null; then
+    echo "提示: 未匹配到「数据库初始化完成」日志（文案/级别可能有变），已按目标库 schema 就绪判定"
+fi
+echo "schema 已建好"
+
+echo "=== C2b TRUNCATE 业务表（清默认 config 行）==="
+TABLES=$(psql "$PGURL_NOPASS" -Atc \
+    "SELECT string_agg(tablename, ', ') FROM pg_tables WHERE schemaname='public' AND tablename<>'seaql_migrations';")
+[[ -n "$TABLES" ]] || { echo "错误: 目标库无业务表（bili-sync 建 schema 失败？）" >&2; exit 1; }
+psql "$PGURL_NOPASS" -v ON_ERROR_STOP=1 -c "TRUNCATE $TABLES RESTART IDENTITY;" > /dev/null
+echo "已清空业务表: $TABLES"
+
+echo "=== C3 动态生成迁移配置 ==="
+CONF="$TMP_DIR/migrate.load"
+bash "$SCRIPT_DIR/gen-migrate-conf.sh" "$PGURL" "$SQLITE_DB" "$CONF"
+
+echo "=== C4 执行导入（pgloader）==="
+pgloader "$CONF" 2>&1 | tee "$TMP_DIR/pgloader.log"
+
+echo "=== C4b 序列对齐（修复 reset sequences 对空表的重置）==="
+# pgloader reset sequences 实测（3.6.10）：非空表 last_value=MAX(id)、is_called=true（对齐），
+# 空表被重置成 last_value=1、is_called=true（下一个分配值跳 1）。统一按 MAX(id) 幂等重设：
+# 非空表 setval(seq, MAX(id), true) -> 下一值 MAX(id)+1；空表 setval(seq, 1, false) -> 下一值 1
+psql "$PGURL_NOPASS" -v ON_ERROR_STOP=1 -c "
+DO \$\$
+DECLARE
+    r record;
+    max_id bigint;
+BEGIN
+    FOR r IN
+        SELECT tablename FROM pg_tables
+        WHERE schemaname = 'public' AND tablename <> 'seaql_migrations'
+    LOOP
+        CONTINUE WHEN pg_get_serial_sequence(r.tablename, 'id') IS NULL;
+        EXECUTE format('SELECT COALESCE(MAX(id), 0) FROM %I', r.tablename) INTO max_id;
+        PERFORM setval(pg_get_serial_sequence(r.tablename, 'id'), GREATEST(max_id, 1), max_id > 0);
+    END LOOP;
+END
+\$\$;" > /dev/null
+echo "序列已按 MAX(id) 对齐（含空表）"
+
+echo "=== C5 行数对账（源 SQLite vs 目标 PG）==="
+# pgloader 行级错误（如时间戳无法解析）不会反映到退出码：实测 3.6.10 整表 COPY
+# 失败仍 exit 0，仅 summary 的 errors 列有计数。导入后必须对账行数兜底。
+# 用 count(*) 而非 pg_stat_user_tables.n_live_tup（后者不 ANALYZE 不准，TRUNCATE+COPY 后可能显示 0）
+ROW_FAIL=0
+ALL_TARGET_EMPTY=1
+SRC_TABLES=$(sqlite3 "$SQLITE_DB" "SELECT name FROM sqlite_master
+    WHERE type='table' AND name <> 'seaql_migrations' AND name NOT GLOB 'sqlite_*'
+    ORDER BY name;")
+for t in $SRC_TABLES; do
+    src_n=$(sqlite3 "$SQLITE_DB" "SELECT count(*) FROM \"$t\";")
+    pg_n=$(psql "$PGURL_NOPASS" -Atc "SELECT count(*) FROM \"$t\";")
+    if [[ "$src_n" == "$pg_n" ]]; then
+        printf '%-16s %s = %s ✓\n' "$t" "$src_n" "$pg_n"
+    else
+        printf '%-16s 源 %s != PG %s ✗\n' "$t" "$src_n" "$pg_n" >&2
+        ROW_FAIL=1
+        [[ "$pg_n" == "0" ]] || ALL_TARGET_EMPTY=0
+    fi
+done
+if [[ "$ROW_FAIL" != 0 ]]; then
+    echo "错误: 行数对账不一致，导入不完整（对照上方 pgloader summary 的 errors 列定位）" >&2
+    if [[ "$ALL_TARGET_EMPTY" == 1 ]]; then
+        echo "      目标侧行数全为 0 且 summary 无 errors：多为 pgloader 未读到真实源库" >&2
+        echo "      （.load 的 FROM 未指向源 SQLite，检查 gen-migrate-conf 生成的绝对路径）" >&2
+    fi
+    exit 1
+fi
+echo "迁移完成，行数全部一致"

--- a/scripts/db-migrate/reconcile.sh
+++ b/scripts/db-migrate/reconcile.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# reconcile.sh — 迁移对账：迁移后 PG 库 vs SQLite 源库基线（阶段 C5）
+#
+# 对比项（全部动态推导，不写死表/列）：
+#   行数 / 位域值域 / 时间戳（UTC 文本逐字符） / JSON 归一化 / 布尔计数 /
+#   config md5 / UNIQUE 约束实测 / 序列对齐
+#
+# 用法：
+#   reconcile.sh <SQLITE_DB> <PGURL> [基线目录，默认 SQLITE_DB 同目录 baseline]
+
+set -euo pipefail
+
+SQLITE_DB="${1:?用法: reconcile.sh <SQLITE_DB> <PGURL> [基线目录]}"
+PGURL="${2:?缺 PGURL}"
+BASE="${3:-$(dirname "$SQLITE_DB")/baseline}"
+
+# 从公共库加载 PGURL 结构切分（提取库名/服务器段/query 参数）
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib-pgurl.sh"
+split_pgurl
+# 密码改经 PGPASSWORD 传递：psql 的 argv 会被 `ps` 全程可见，一律用 PGURL_NOPASS
+strip_pg_password
+[[ -n "$PGURL_DB" ]] || { echo "错误: 连接串缺少库名（连接串需形如 postgres://user:pass@host:5432/db）" >&2; exit 1; }
+TARGET_DB="$PGURL_DB"
+
+# sqlite3 连不存在路径会自动建空库文件，路径打错会把空库当作源来对账——必须先验存在
+[[ -f "$SQLITE_DB" ]] || { echo "错误: SQLite 库不存在: $SQLITE_DB" >&2; exit 1; }
+# jq 缺失时 4/8 的「jq ... || echo PARSE_ERR」会让两侧同时输出 PARSE_ERR 假通过——
+# 必须显式前置检查，否则 JSON 对账形同虚设
+command -v jq >/dev/null 2>&1 || { echo "错误: 未安装 jq（4/8 JSON 归一化对账需要）" >&2; exit 1; }
+
+PASS=0; FAIL=0
+ok()   { echo "  ✓ $1"; PASS=$((PASS+1)); }
+bad()  { echo "  ✗ $1"; FAIL=$((FAIL+1)); }
+
+# 业务表清单来自基线（snapshot-baseline.sh 已排除 seaql_migrations 与 SQLite 内部表），
+# 实体加表后重跑 snapshot 即纳入对账，无需改脚本
+[[ -f "$BASE/tables.txt" ]] || { echo "错误: 缺少基线 $BASE/tables.txt（先跑 snapshot-baseline.sh）" >&2; exit 1; }
+mapfile -t TABLES < "$BASE/tables.txt"
+[[ ${#TABLES[@]} -gt 0 ]] || { echo "错误: 基线表清单为空" >&2; exit 1; }
+
+echo "=== 1/8 行数逐表对比（基线: $BASE/rowcounts.txt）==="
+while read -r t n; do
+    pg_n=$(psql "$PGURL_NOPASS" -Atc "SELECT count(*) FROM \"$t\";")
+    if [[ "$n" == "$pg_n" ]]; then ok "$t: $n = $pg_n"; else bad "$t: 基线 $n != PG $pg_n"; fi
+done < "$BASE/rowcounts.txt"
+
+echo "=== 2/8 位域值域对比 ==="
+for t in "${TABLES[@]}"; do
+    sqlite3 "$SQLITE_DB" "PRAGMA table_info(\"$t\");" | grep -q '|download_status|' || continue
+    # ORDER BY 必须显式写列名：ORDER BY 1（SELECT 序号）在标准 PG 里指拼接字符串，
+    # 但部分 PG 兼容引擎解析成分组列——字符串序与数值序不同时（多位数位域值）
+    # 会假报不一致（远程引擎实测踩过，page 恰好两种排序一致而 video 不一致）
+    s=$(sqlite3 "$SQLITE_DB" "SELECT download_status || ':' || count(*) FROM \"$t\" GROUP BY download_status ORDER BY download_status;" | md5sum | cut -d' ' -f1)
+    p=$(psql "$PGURL_NOPASS" -Atc "SELECT download_status || ':' || count(*) FROM \"$t\" GROUP BY download_status ORDER BY download_status;" | md5sum | cut -d' ' -f1)
+    if [[ "$s" == "$p" ]]; then ok "$t 位域一致 ($s)"; else bad "$t 位域: SQLite[$s] != PG[$p]"; fi
+done
+
+echo "=== 3/8 时间戳全量对比（UTC 文本逐字符）==="
+# 不用 epoch 换算：SQLite strftime('%s') 经 float64 舍入、PG EXTRACT(EPOCH)::bigint
+# 四舍五入，亚秒 ≥0.5 的时间戳两侧都不准（会假报差异）；直接比较文本最可靠。
+# 亚秒归一化：两侧 rtrim 尾部 0（'.500000' == '.5' 视为同一值）。
+for t in "${TABLES[@]}"; do
+    cols=$(sqlite3 "$SQLITE_DB" "PRAGMA table_info(\"$t\");" | awk -F'|' '$3 ~ /timestamp_text/ {print $2}')
+    for c in $cols; do
+        s=$(sqlite3 "$SQLITE_DB" "SELECT id || '=' || rtrim(strftime('%Y-%m-%d %H:%M:%S', \"$c\") || CASE WHEN instr(\"$c\",'.')>0 THEN substr(\"$c\",instr(\"$c\",'.')) ELSE '.0' END, '0') FROM \"$t\" ORDER BY id;" | md5sum | cut -d' ' -f1)
+        p=$(psql "$PGURL_NOPASS" -Atc "SELECT id || '=' || rtrim(to_char(\"$c\", 'YYYY-MM-DD HH24:MI:SS.US'), '0') FROM \"$t\" ORDER BY id;" | md5sum | cut -d' ' -f1)
+        if [[ "$s" == "$p" ]]; then ok "$t.$c 时间戳一致 ($s)"; else bad "$t.$c 时间戳: SQLite[$s] != PG[$p]"; fi
+    done
+done
+
+echo "=== 4/8 JSON 归一化对比 ==="
+for t in "${TABLES[@]}"; do
+    cols=$(sqlite3 "$SQLITE_DB" "PRAGMA table_info(\"$t\");" | awk -F'|' '$3 ~ /json/ {print $2}')
+    for c in $cols; do
+        s=$(sqlite3 "$SQLITE_DB" "SELECT COALESCE(\"$c\",'NULL') FROM \"$t\" ORDER BY id;" | while read -r v; do
+                [[ "$v" == "NULL" ]] && { echo NULL; continue; }
+                echo "$v" | jq -c -S . 2>/dev/null || echo "PARSE_ERR"
+            done | md5sum | cut -d' ' -f1)
+        p=$(psql "$PGURL_NOPASS" -Atc "SELECT COALESCE(\"$c\"::text,'NULL') FROM \"$t\" ORDER BY id;" | while read -r v; do
+                [[ "$v" == "NULL" ]] && { echo NULL; continue; }
+                echo "$v" | jq -c -S . 2>/dev/null || echo "PARSE_ERR"
+            done | md5sum | cut -d' ' -f1)
+        if [[ "$s" == "$p" ]]; then ok "$t.$c JSON 归一化一致 ($s)"; else bad "$t.$c JSON: SQLite[$s] != PG[$p]"; fi
+    done
+done
+
+echo "=== 5/8 布尔计数对比 ==="
+# SQLite 布尔存 0/1，PG 侧 ::int 对齐；NULL 两侧统一归一化为 'null' 再排序
+# （SQLite ORDER BY 空值在前、PG 空值在后，不归一化会假报差异）
+for t in "${TABLES[@]}"; do
+    cols=$(sqlite3 "$SQLITE_DB" "PRAGMA table_info(\"$t\");" | awk -F'|' '$3=="boolean" {print $2}')
+    for c in $cols; do
+        s=$(sqlite3 "$SQLITE_DB" "SELECT COALESCE(\"$c\",'null') || ':' || count(*) FROM \"$t\" GROUP BY \"$c\" ORDER BY 1;" | md5sum | cut -d' ' -f1)
+        p=$(psql "$PGURL_NOPASS" -Atc "SELECT COALESCE(\"$c\"::int::text,'null') || ':' || count(*) FROM \"$t\" GROUP BY \"$c\" ORDER BY 1;" | md5sum | cut -d' ' -f1)
+        if [[ "$s" == "$p" ]]; then ok "$t.$c 布尔分布一致 ($s)"; else bad "$t.$c 布尔: SQLite[$s] != PG[$p]"; fi
+    done
+done
+
+echo "=== 6/8 config md5 对比（迁移时点基线）==="
+# 不能用 COPY TO STDOUT：COPY 文本格式会把数据内的反斜杠/换行转义，
+# config 含这些字节时会假报不一致；SELECT 原样输出（两侧各带一个行尾换行）
+pg_md5=$(psql "$PGURL_NOPASS" -Atc "SELECT data FROM config WHERE id=1;" | md5sum | cut -d' ' -f1)
+base_md5=$(cut -d' ' -f1 "$BASE/config.md5")
+if [[ "$pg_md5" == "$base_md5" ]]; then ok "config md5 一致: $pg_md5"; else bad "config md5: 基线[$base_md5] != PG[$pg_md5]"; fi
+
+echo "=== 7/8 UNIQUE 约束实测（复制一行插入应触发 idx_video_unique 冲突）==="
+video_rows=$(psql "$PGURL_NOPASS" -Atc "SELECT count(*) FROM video;")
+if [[ "$video_rows" == "0" ]]; then
+    ok "video 为空，跳过 UNIQUE 冲突实测"
+else
+    # 列清单动态推导（实体加列后无需改脚本）；显式写 id = MAX(id)+1，
+    # 不走序列默认值——序列非事务性，ROLLBACK 不还原 nextval，会扰动 8/8 的序列判读
+    cols=$(psql "$PGURL_NOPASS" -Atc \
+        "SELECT string_agg(column_name, ', ' ORDER BY ordinal_position) FROM information_schema.columns
+         WHERE table_schema='public' AND table_name='video' AND column_name <> 'id';")
+    err_file=$(mktemp)
+    # UNIQUE 实测可能被中断（SIGINT/SIGTERM）而残留临时文件，EXIT trap 兜底清理
+    trap '[[ -n "${err_file:-}" ]] && rm -f "$err_file"' EXIT
+    if psql "$PGURL_NOPASS" -v ON_ERROR_STOP=1 -Atc \
+        "BEGIN; INSERT INTO video (id, $cols) SELECT (SELECT COALESCE(MAX(id),0)+1 FROM video), $cols FROM video ORDER BY id LIMIT 1; ROLLBACK;" \
+        > /dev/null 2>"$err_file"; then
+        bad "插入重复 bvid 未报错（UNIQUE 索引失效？）"
+    elif grep -q 'idx_video_unique' "$err_file"; then
+        ok "插入重复 bvid 触发 idx_video_unique 冲突（COALESCE 索引生效）"
+    else
+        bad "插入失败但非 idx_video_unique 冲突: $(tail -1 "$err_file")"
+    fi
+    rm -f "$err_file"
+fi
+
+echo "=== 8/8 序列对齐（下一个分配值 == MAX(id)+1）==="
+# pgloader reset sequences 的实测行为（3.6.10）：非空表 last_value=MAX(id)、
+# is_called=true（对齐）；空表 last_value=1、is_called=true（跳 1 号），需手动 setval。
+# 正确性判据：next = is_called ? last+1 : last，必须 == MAX(id)+1
+for t in "${TABLES[@]}"; do
+    seq=$(psql "$PGURL_NOPASS" -Atc "SELECT pg_get_serial_sequence('$t','id');")
+    [[ -n "$seq" ]] || continue
+    IFS='|' read -r last called < <(psql "$PGURL_NOPASS" -Atc "SELECT last_value, is_called FROM $seq;")
+    maxid=$(psql "$PGURL_NOPASS" -Atc "SELECT COALESCE(MAX(id),0) FROM \"$t\";")
+    # psql 中途失败时读到的值为空，裸算术会以语法错误收场——先防御再判读
+    if [[ -z "$last" || -z "$called" || -z "$maxid" ]]; then
+        bad "$t 序列读取失败（last=$last is_called=$called max=$maxid），无法判读"
+        continue
+    fi
+    if [[ "$called" == "t" ]]; then next=$((last + 1)); else next=$last; fi
+    if [[ "$next" == "$((maxid + 1))" ]]; then
+        ok "$t 序列对齐 (next=$next, max=$maxid)"
+    else
+        bad "$t 序列未对齐 (last=$last is_called=$called, next=$next, max=$maxid) → 需手动 setval"
+    fi
+done
+
+echo ""
+echo "对账结果: PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/scripts/db-migrate/snapshot-baseline.sh
+++ b/scripts/db-migrate/snapshot-baseline.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# snapshot-baseline.sh — 导出 SQLite 库形态基线（迁移前冻结 + 迁移后对账的对照基准）
+#
+# 用途：SQLite→PG 迁移实测验证的阶段 B（B2）。
+#   在迁移源库冻结（实例停止 + WAL checkpoint）后运行，导出：
+#     表清单 / 行数 / 完整 DDL / 列信息 / 位域值域 / 时间戳抽样 /
+#     JSON 抽样 / NULL 分布 / 布尔分布 / config md5 / integrity_check
+#   全部动态推导（遍历 sqlite_master / PRAGMA），不写死表名列名——
+#   维护者加表加列后重跑即得到新基线，无需改脚本。
+#
+# 用法：
+#   snapshot-baseline.sh <SQLITE_DB> <输出目录>
+#
+# 前置条件：迁移源库已冻结（bili-sync 已停止、WAL 已 checkpoint）。
+
+set -euo pipefail
+
+SQLITE_DB="${1:?用法: snapshot-baseline.sh <SQLITE_DB> <输出目录>}"
+OUT="${2:?缺输出目录}"
+# sqlite3 连不存在路径会自动建空库文件，路径打错会导出空基线——必须先验存在
+[[ -f "$SQLITE_DB" ]] || { echo "错误: SQLite 库不存在: $SQLITE_DB" >&2; exit 1; }
+# sqlite3 连不存在路径会自动建空库文件，路径打错会导出空基线——必须先验非空
+# （校验集合与下方 tables() 一致：排除 seaql_migrations 与 SQLite 内部表）
+[[ "$(sqlite3 "$SQLITE_DB" "SELECT count(*) FROM sqlite_master
+    WHERE type='table' AND name NOT IN ('seaql_migrations','sqlite_sequence','sqlite_stat1','sqlite_stat4');")" != "0" ]] \
+    || { echo "错误: SQLite 库无业务表（空库或路径错误）: $SQLITE_DB" >&2; exit 1; }
+mkdir -p "$OUT"
+
+# 业务表清单（排除 seaql_migrations 与 SQLite 内部表）
+tables() {
+    sqlite3 "$SQLITE_DB" "SELECT name FROM sqlite_master
+        WHERE type='table' AND name NOT IN ('seaql_migrations','sqlite_sequence','sqlite_stat1','sqlite_stat4')
+        ORDER BY name;"
+}
+
+echo "=== 1/9 完整性检查 ==="
+sqlite3 "$SQLITE_DB" "PRAGMA integrity_check;" > "$OUT/integrity.txt"
+cat "$OUT/integrity.txt"
+# 完整性检查必须每一行都是 ok（大库可能输出多行）——损坏库导出基线毫无意义，
+# 下游对账全链路都会基于垃圾数据
+if grep -qvx 'ok' "$OUT/integrity.txt" || [[ ! -s "$OUT/integrity.txt" ]]; then
+    echo "错误: SQLite 完整性检查失败（PRAGMA integrity_check 非 ok）: $(tr '\n' ' ' < "$OUT/integrity.txt")" >&2
+    exit 1
+fi
+
+echo "=== 2/9 表清单 ==="
+tables > "$OUT/tables.txt"
+cat "$OUT/tables.txt"
+echo "迁移记录数: $(sqlite3 "$SQLITE_DB" "SELECT count(*) FROM seaql_migrations;")"
+
+echo "=== 3/9 行数 ==="
+: > "$OUT/rowcounts.txt"
+while read -r t; do
+    printf '%-16s %s\n' "$t" "$(sqlite3 "$SQLITE_DB" "SELECT count(*) FROM \"$t\";")" >> "$OUT/rowcounts.txt"
+done < "$OUT/tables.txt"
+cat "$OUT/rowcounts.txt"
+
+echo "=== 4/9 完整 DDL ==="
+sqlite3 "$SQLITE_DB" ".schema" > "$OUT/schema.sql"
+echo "已导出 schema.sql ($(wc -l < "$OUT/schema.sql") 行)"
+
+echo "=== 5/9 列信息（PRAGMA table_info）==="
+: > "$OUT/table_info.txt"
+while read -r t; do
+    {
+        echo "--- $t ---"
+        sqlite3 "$SQLITE_DB" "PRAGMA table_info(\"$t\");"
+    } >> "$OUT/table_info.txt"
+done < "$OUT/tables.txt"
+grep -c '^---' "$OUT/table_info.txt" | xargs echo "共导出表信息份数:"
+
+echo "=== 6/9 位域值域（download_status 列的表）==="
+: > "$OUT/status_groups.txt"
+for t in $(tables); do
+    if sqlite3 "$SQLITE_DB" "PRAGMA table_info(\"$t\");" | grep -q '|download_status|'; then
+        echo "--- $t ---" >> "$OUT/status_groups.txt"
+        sqlite3 "$SQLITE_DB" "SELECT download_status, count(*) FROM \"$t\" GROUP BY download_status ORDER BY 1;" >> "$OUT/status_groups.txt"
+    fi
+done
+cat "$OUT/status_groups.txt"
+
+echo "=== 7/9 时间戳与 JSON 抽样（timestamp_text/json_text/jsonb_text 列）==="
+: > "$OUT/sample.txt"
+for t in $(tables); do
+    cols=$(sqlite3 "$SQLITE_DB" "PRAGMA table_info(\"$t\");" | awk -F'|' '$3 ~ /timestamp_text|json_text|jsonb_text/ {print $2}')
+    for c in $cols; do
+        echo "--- $t.$c ---" >> "$OUT/sample.txt"
+        sqlite3 "$SQLITE_DB" "SELECT substr(\"$c\",1,60) FROM \"$t\" LIMIT 3;" >> "$OUT/sample.txt"
+    done
+done
+cat "$OUT/sample.txt"
+
+echo "=== 8/9 NULL 与布尔分布（可空/boolean 列）==="
+: > "$OUT/null_bool.txt"
+for t in $(tables); do
+    sqlite3 "$SQLITE_DB" "PRAGMA table_info(\"$t\");" | awk -F'|' 'BEGIN{printf "--- %s ---\n", "'"$t"'"} $3=="boolean"{printf "BOOL %s\n", $2} $4=="0"{printf "NULLABLE %s\n", $2}' >> "$OUT/null_bool.txt"
+done
+# 对每个可空列统计 NULL 数、对每个 boolean 列统计 0/1 分布
+: > "$OUT/null_counts.txt"
+for t in $(tables); do
+    while read -r c; do
+        n=$(sqlite3 "$SQLITE_DB" "SELECT count(*) FROM \"$t\" WHERE \"$c\" IS NULL;")
+        echo "$t.$c NULL=$n" >> "$OUT/null_counts.txt"
+    done < <(sqlite3 "$SQLITE_DB" "PRAGMA table_info(\"$t\");" | awk -F'|' '$4=="0" && $2!="id" {print $2}')
+    while read -r c; do
+        sqlite3 "$SQLITE_DB" "SELECT \"$c\", count(*) FROM \"$t\" GROUP BY \"$c\" ORDER BY 1;" | sed "s/^/$t.$c = /" >> "$OUT/null_bool.txt"
+    done < <(sqlite3 "$SQLITE_DB" "PRAGMA table_info(\"$t\");" | awk -F'|' '$3=="boolean" {print $2}')
+done
+cat "$OUT/null_counts.txt"
+
+echo "=== 9/9 config md5 ==="
+sqlite3 "$SQLITE_DB" "SELECT data FROM config WHERE id=1;" | md5sum > "$OUT/config.md5"
+cat "$OUT/config.md5"
+
+echo "基线导出完成 → $OUT"


### PR DESCRIPTION
## 概述

为 bili-sync 增加 PostgreSQL 数据库后端支持，并附带一套 SQLite→PostgreSQL 数据迁移实测验证工具链。

## 主要变更

### 数据库后端（Rust）

- 新增 `--database-url` 参数（环境变量 `BILI_SYNC_DATABASE_URL`），支持 `postgres://` 连接串切换到 PostgreSQL；SQLite（默认，WAL）行为保持兼容
- 数据库连接层按连接串 scheme 区分后端（`src/database.rs`）：大小写不敏感、白名单外显式报错；迁移在启动时自动执行
- 实体层（`bili_sync_entity`）与迁移层（`bili_sync_migration`）适配 PostgreSQL：列类型映射、`COALESCE` 唯一索引、`(CURRENT_TIMESTAMP AT TIME ZONE 'UTC')` 默认值、`IFNULL→COALESCE` 数据回填等
- 时间语义统一：`created_at` 一律按 UTC 存储，日期筛选与仪表盘分桶按程序所在服务器本地时区换算（SQLite/PG 两侧行为一致；DST 过渡窗口内的边界差异已加注释说明）
- 状态位域统一 i64 载体（u32→i64）
- 视频源更新支持显式清空规则并保留既有规则

### 数据迁移工具链（`scripts/db-migrate/`）

面向维护者的 SQLite→PostgreSQL 迁移实测验证工具链：

- `migrate.sh`：校验/准备目标库 → bili-sync 建 schema → TRUNCATE → pgloader 导入 → 序列对齐 + 行数对账（pgloader 行级错误不反映退出码，对账兜底）
- `reconcile.sh` / `compare-ddl.sh` / `compare-data.sh`：对账与 DDL/数据格式对比（统一 FAIL>0 → exit 1，可串联或接入 CI）
- `inject-credential.sh` / `snapshot-baseline.sh`：凭证制备与 SQLite 形态基线导出
- 表清单与 cast 规则全部从数据库 catalog 动态推导，不手写清单（实体加表/加列后重跑即得新配置）
- 凭证安全：密码经 `PGPASSWORD` 传递（不进 psql/pg_dump argv）、临时目录 0700 退出自动清理、生成的 pgloader `.load` 文件 0600

## 测试

- `cargo test`：新增 SQLite 兼容回归测试（created_at UTC 语义、dashboard SQLite 分支），全量通过
- 迁移工具链开发期已对 PostgreSQL 全链路 e2e 实测（行数对账/序列对齐/DDL 对比全绿），批量状态更新 SQL 在 PostgreSQL 16 上复核通过
